### PR TITLE
fix bugs and refactor children playback handling in parent

### DIFF
--- a/lib/membrane/child_entry.ex
+++ b/lib/membrane/child_entry.ex
@@ -11,6 +11,8 @@ defmodule Membrane.ChildEntry do
   Other fields in the struct ARE NOT PART OF THE PUBLIC API and should not be
   accessed or relied on.
   """
+  use Bunch.Access
+
   @type t :: %__MODULE__{
           name: Membrane.Child.name_t(),
           module: module,
@@ -19,8 +21,17 @@ defmodule Membrane.ChildEntry do
           pid: pid,
           clock: Membrane.Clock.t(),
           sync: Membrane.Sync.t(),
-          pending?: boolean()
+          playback_synced?: boolean()
         }
 
-  defstruct [:name, :module, :options, :component_type, :pid, :clock, :sync, :pending?]
+  defstruct [
+    :name,
+    :module,
+    :options,
+    :component_type,
+    :pid,
+    :clock,
+    :sync,
+    playback_synced?: false
+  ]
 end

--- a/lib/membrane/child_entry.ex
+++ b/lib/membrane/child_entry.ex
@@ -21,7 +21,8 @@ defmodule Membrane.ChildEntry do
           pid: pid,
           clock: Membrane.Clock.t(),
           sync: Membrane.Sync.t(),
-          playback_synced?: boolean()
+          playback_synced?: boolean(),
+          terminating?: boolean()
         }
 
   defstruct [
@@ -32,6 +33,7 @@ defmodule Membrane.ChildEntry do
     :pid,
     :clock,
     :sync,
-    playback_synced?: false
+    playback_synced?: false,
+    terminating?: false
   ]
 end

--- a/lib/membrane/core/bin/linking_buffer.ex
+++ b/lib/membrane/core/bin/linking_buffer.ex
@@ -60,7 +60,7 @@ defmodule Membrane.Core.Bin.LinkingBuffer do
         bin_state
 
       {msgs, new_buf} ->
-        msgs |> Enum.each(&do_flush(&1, pad, bin_state))
+        msgs |> Enum.reverse() |> Enum.each(&do_flush(&1, pad, bin_state))
         %{bin_state | linking_buffer: new_buf}
     end
   end

--- a/lib/membrane/core/bin/linking_buffer.ex
+++ b/lib/membrane/core/bin/linking_buffer.ex
@@ -48,7 +48,7 @@ defmodule Membrane.Core.Bin.LinkingBuffer do
     do: pad in state.pads.dynamic_currently_linking
 
   @doc """
-  Sends messages stored for a given outpud pad.
+  Sends messages stored for a given output pad.
   A link must already be available.
   """
   @spec flush_for_pad(Pad.ref_t(), State.t()) :: State.t()

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -147,7 +147,9 @@ defmodule Membrane.Core.Element.LifecycleController do
   end
 
   @impl PlaybackHandler
-  def handle_playback_state_changed(_old, new, state) do
+  def handle_playback_state_changed(old, new, state) do
+    Membrane.Logger.debug_verbose("Playback state changed from #{old} to #{new}")
+
     if new == :stopped, do: unlink(state.pads.data)
 
     with {:ok, state} <- PlaybackBuffer.eval(state) do

--- a/lib/membrane/core/parent/child_entry_parser.ex
+++ b/lib/membrane/core/parent/child_entry_parser.ex
@@ -7,11 +7,7 @@ defmodule Membrane.Core.Parent.ChildEntryParser do
           name: Membrane.Child.name_t(),
           module: module,
           options: struct | nil,
-          component_type: :element | :bin,
-          pid: pid | nil,
-          clock: Membrane.Clock.t() | nil,
-          sync: Membrane.Sync.t() | nil,
-          pending?: boolean()
+          component_type: :element | :bin
         }
 
   @spec from_spec(ParentSpec.children_spec_t() | any) :: [raw_child_entry_t] | no_return
@@ -24,8 +20,7 @@ defmodule Membrane.Core.Parent.ChildEntryParser do
       name: name,
       module: module,
       options: options,
-      component_type: component_type(module),
-      pending?: false
+      component_type: component_type(module)
     }
   end
 
@@ -36,8 +31,7 @@ defmodule Membrane.Core.Parent.ChildEntryParser do
       name: name,
       module: module,
       options: options,
-      component_type: component_type(module),
-      pending?: false
+      component_type: component_type(module)
     }
   end
 

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -5,13 +5,12 @@ defmodule Membrane.Core.Parent.ChildLifeController do
   alias __MODULE__.{StartupHandler, LinkHandler}
   alias Membrane.ParentSpec
   alias Membrane.Core.Parent
-  alias Membrane.Core.Parent.{ChildEntryParser, ClockHandler, Link}
+  alias Membrane.Core.Parent.{ChildEntryParser, ClockHandler, LifecycleController, Link}
   alias Membrane.Core.PlaybackHandler
 
   require Membrane.Logger
   require Membrane.Bin
   require Membrane.Element
-  require Membrane.PlaybackState
 
   @spec handle_spec(ParentSpec.t(), Parent.state_t()) ::
           {{:ok, [Membrane.Child.name_t()]}, Parent.state_t()} | no_return
@@ -53,27 +52,6 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     {result, state}
   end
 
-  @spec handle_remove_child(Membrane.Child.name_t() | [Membrane.Child.name_t()], Parent.state_t()) ::
-          {:ok | {:error, any}, Parent.state_t()}
-  def handle_remove_child(children, state) do
-    children = children |> Bunch.listify()
-
-    {:ok, state} =
-      if state.synchronization.clock_provider.provider in children do
-        ClockHandler.reset_clock(state)
-      else
-        {:ok, state}
-      end
-
-    with {:ok, data} <-
-           children |> Bunch.Enum.try_map(&Parent.ChildrenModel.get_child_data(state, &1)) do
-      data |> Enum.each(&Process.monitor(&1.pid))
-      data |> Enum.each(&PlaybackHandler.request_playback_state_change(&1.pid, :terminating))
-      :ok
-    end
-    ~> {&1, state}
-  end
-
   defp do_handle_forward({child_name, message}, state) do
     with {:ok, %{pid: pid}} <- state |> Parent.ChildrenModel.get_child_data(child_name) do
       send(pid, message)
@@ -82,5 +60,75 @@ defmodule Membrane.Core.Parent.ChildLifeController do
       {:error, reason} ->
         {:error, {:cannot_forward_message, [element: child_name, message: message], reason}}
     end
+  end
+
+  @spec handle_remove_child(Membrane.Child.name_t() | [Membrane.Child.name_t()], Parent.state_t()) ::
+          {:ok | {:error, any}, Parent.state_t()}
+  def handle_remove_child(names, state) do
+    names = names |> Bunch.listify()
+
+    {:ok, state} =
+      if state.synchronization.clock_provider.provider in names do
+        ClockHandler.reset_clock(state)
+      else
+        {:ok, state}
+      end
+
+    with {:ok, data} <- Bunch.Enum.try_map(names, &Parent.ChildrenModel.get_child_data(state, &1)) do
+      {already_removing, data} = Enum.split_with(data, & &1.terminating?)
+
+      if already_removing != [] do
+        Membrane.Logger.warn("""
+        Trying to remove children that are already being removed: #{
+          Enum.map_join(already_removing, ", ", &inspect(&1.name))
+        }. This may lead to 'unknown child' errors.
+        """)
+      end
+
+      data |> Enum.each(&Process.monitor(&1.pid))
+      data |> Enum.each(&PlaybackHandler.request_playback_state_change(&1.pid, :terminating))
+
+      {:ok, state} =
+        Parent.ChildrenModel.update_children(state, names, &%{&1 | terminating?: true})
+
+      {:ok, state}
+    else
+      error -> {error, state}
+    end
+  end
+
+  @spec child_playback_changed(pid, Membrane.PlaybackState.t(), Parent.state_t()) ::
+          {:ok | {:error, any}, Parent.state_t()}
+  def child_playback_changed(pid, child_pb_state, state) do
+    child = child_by_pid(pid, state)
+    %{playback: playback} = state
+
+    cond do
+      playback.pending_state == nil and playback.state == child_pb_state ->
+        state = put_in(state, [:children, child, :playback_synced?], true)
+        {:ok, state}
+
+      playback.pending_state == child_pb_state ->
+        state = put_in(state, [:children, child, :playback_synced?], true)
+        LifecycleController.maybe_finish_playback_transition(state)
+
+      true ->
+        {:ok, state}
+    end
+  end
+
+  @spec handle_child_death(child_pid :: pid(), reason :: atom(), state :: Parent.state_t()) ::
+          {:ok, Parent.state_t()}
+  def handle_child_death(pid, :normal, state) do
+    child = child_by_pid(pid, state)
+    state = Bunch.Access.delete_in(state, [:children, child])
+    LifecycleController.maybe_finish_playback_transition(state)
+  end
+
+  defp child_by_pid(pid, state) do
+    {child_name, _child_data} =
+      Enum.find(state.children, fn {_name, entry} -> entry.pid == pid end)
+
+    child_name
   end
 end

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -194,8 +194,8 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
     endpoints =
       links
       |> Enum.flat_map(&[&1.from, &1.to])
-      |> Enum.uniq()
       |> Enum.reject(&(&1.child == {Membrane.Bin, :itself}))
+      |> Enum.uniq()
 
     Bunch.Enum.try_each(endpoints, &Message.call(&1.pid, :linking_finished))
   end

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -191,12 +191,10 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
   end
 
   defp send_linking_finished(links) do
-    endpoints =
-      links
-      |> Enum.flat_map(&[&1.from, &1.to])
-      |> Enum.reject(&(&1.child == {Membrane.Bin, :itself}))
-      |> Enum.uniq()
-
-    Bunch.Enum.try_each(endpoints, &Message.call(&1.pid, :linking_finished))
+    links
+    |> Enum.flat_map(&[&1.from, &1.to])
+    |> Enum.reject(&(&1.child == {Membrane.Bin, :itself}))
+    |> Enum.uniq()
+    |> Bunch.Enum.try_each(&Message.call(&1.pid, :linking_finished))
   end
 end

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -33,9 +33,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
     state = links |> Enum.reduce(state, &link/2)
 
     with :ok <-
-           state
-           |> Parent.ChildrenModel.get_children()
-           |> Bunch.Enum.try_each(fn {_name, %{pid: pid}} ->
+           Bunch.Enum.try_each(state.children, fn {_name, %{pid: pid}} ->
              pid |> Message.call(:linking_finished, [])
            end) do
       links

--- a/lib/membrane/core/parent/children_model.ex
+++ b/lib/membrane/core/parent/children_model.ex
@@ -40,9 +40,10 @@ defmodule Membrane.Core.Parent.ChildrenModel do
   def update_children(state, children_names, mapper) do
     result =
       Bunch.Enum.try_reduce(children_names, state.children, fn name, children ->
-        case Map.fetch(children, name) do
-          {:ok, child} -> {:ok, %{children | name => mapper.(child)}}
-          :error -> {:error, {:unknown_child, name}}
+        if Map.has_key?(children, name) do
+          {:ok, Map.update!(children, name, mapper)}
+        else
+          {:error, {:unknown_child, name}}
         end
       end)
 

--- a/lib/membrane/core/parent/children_model.ex
+++ b/lib/membrane/core/parent/children_model.ex
@@ -1,13 +1,13 @@
 defmodule Membrane.Core.Parent.ChildrenModel do
   @moduledoc false
 
-  alias Membrane.ChildEntry
+  alias Membrane.{Child, ChildEntry}
   alias Membrane.Core.Parent
 
-  @type children_t :: %{Membrane.Child.name_t() => ChildEntry.t()}
+  @type children_t :: %{Child.name_t() => ChildEntry.t()}
 
-  @spec add_child(Parent.state_t(), Membrane.Child.name_t(), ChildEntry.t()) ::
-          {:ok | {:error, {:duplicate_child, Membrane.Child.name_t()}}, Parent.state_t()}
+  @spec add_child(Parent.state_t(), Child.name_t(), ChildEntry.t()) ::
+          {:ok | {:error, {:duplicate_child, Child.name_t()}}, Parent.state_t()}
   def add_child(%{children: children} = state, child, data) do
     if Map.has_key?(children, child) do
       {{:error, {:duplicate_child, child}}, state}
@@ -16,16 +16,16 @@ defmodule Membrane.Core.Parent.ChildrenModel do
     end
   end
 
-  @spec get_child_data(Parent.state_t(), Membrane.Child.name_t()) ::
+  @spec get_child_data(Parent.state_t(), Child.name_t()) ::
           {:ok, child_data :: ChildEntry.t()}
-          | {:error, {:unknown_child, Membrane.Child.name_t()}}
+          | {:error, {:unknown_child, Child.name_t()}}
   def get_child_data(%{children: children}, child) do
     children[child] |> Bunch.error_if_nil({:unknown_child, child})
   end
 
-  @spec pop_child(Parent.state_t(), Membrane.Child.name_t()) ::
+  @spec pop_child(Parent.state_t(), Child.name_t()) ::
           {{:ok, child_data :: ChildEntry.t()}
-           | {:error, {:unknown_child, Membrane.Child.name_t()}}, Parent.state_t()}
+           | {:error, {:unknown_child, Child.name_t()}}, Parent.state_t()}
   def pop_child(%{children: children} = state, child) do
     {pid, children} = children |> Map.pop(child)
 
@@ -35,28 +35,34 @@ defmodule Membrane.Core.Parent.ChildrenModel do
     end
   end
 
-  @spec get_children_names(Parent.state_t()) :: [Membrane.Child.name_t()]
-  def get_children_names(%{children: children}) do
-    children |> Map.keys()
+  @spec update_children(Parent.state_t(), [Child.name_t()], (ChildEntry.t() -> ChildEntry.t())) ::
+          {:ok, Parent.state_t()} | {:error, {:unknown_child, Child.name_t()}}
+  def update_children(state, children_names, mapper) do
+    result =
+      Bunch.Enum.try_reduce(children_names, state.children, fn name, children ->
+        case Map.fetch(children, name) do
+          {:ok, child} -> {:ok, %{children | name => mapper.(child)}}
+          :error -> {:error, {:unknown_child, name}}
+        end
+      end)
+
+    with {:ok, children} <- result do
+      {:ok, %{state | children: children}}
+    end
   end
 
-  @spec get_children(Parent.state_t()) :: children_t
-  def get_children(%{children: children}) do
-    children
-  end
-
-  @spec update_children(Parent.state_t(), fun()) ::
-          Parent.state_t()
+  @spec update_children(Parent.state_t(), (ChildEntry.t() -> ChildEntry.t())) ::
+          {:ok, Parent.state_t()}
   def update_children(state, mapper) do
     children =
       state.children
       |> Enum.map(fn {name, entry} -> {name, mapper.(entry)} end)
       |> Enum.into(%{})
 
-    %{state | children: children}
+    {:ok, %{state | children: children}}
   end
 
-  @spec all?(Parent.state_t(), fun()) :: boolean()
+  @spec all?(Parent.state_t(), (ChildEntry.t() -> as_boolean(term))) :: boolean()
   def all?(state, predicate) do
     state.children
     |> Enum.all?(fn {_k, v} -> predicate.(v) end)

--- a/lib/membrane/core/parent/lifecycle_controller.ex
+++ b/lib/membrane/core/parent/lifecycle_controller.ex
@@ -17,18 +17,12 @@ defmodule Membrane.Core.Parent.LifecycleController do
   @impl PlaybackHandler
   def handle_playback_state(old, new, state) do
     Membrane.Logger.debug("Changing playback state from #{old} to #{new}")
-
     children_data = state |> ChildrenModel.get_children() |> Map.values()
-    children_pids = children_data |> Enum.map(& &1.pid)
-
-    children_pids
-    |> Enum.each(&PlaybackHandler.request_playback_state_change(&1, new))
-
+    Enum.each(children_data, &PlaybackHandler.request_playback_state_change(&1.pid, new))
     :ok = toggle_syncs_active(old, new, children_data)
+    state = ChildrenModel.update_children(state, &%{&1 | playback_synced?: false})
 
-    state = state |> ChildrenModel.update_children(&%{&1 | pending?: true})
-
-    if children_pids |> Enum.empty?() do
+    if children_data |> Enum.empty?() do
       {:ok, state}
     else
       PlaybackHandler.suspend_playback_change(state)
@@ -55,17 +49,13 @@ defmodule Membrane.Core.Parent.LifecycleController do
       end
 
     with {:ok, state} <- callback_res do
-      case state do
-        %Core.Pipeline.State{} ->
-          Membrane.Logger.info("Pipeline playback state changed from #{old} to #{new}")
+      Membrane.Logger.debug("Playback state changed from #{old} to #{new}")
 
-        %Core.Bin.State{} ->
-          Membrane.Logger.debug("Playback state changed from #{old} to #{new}")
+      if new == :terminating do
+        {:stop, :normal, state}
+      else
+        {:ok, state}
       end
-
-      if new == :terminating,
-        do: {:stop, :normal, state},
-        else: callback_res
     end
   end
 
@@ -111,51 +101,30 @@ defmodule Membrane.Core.Parent.LifecycleController do
 
   @spec child_playback_changed(pid, PlaybackState.t(), Parent.state_t()) ::
           PlaybackHandler.handler_return_t()
-  def child_playback_changed(pid, new_pb_state, state) do
-    if transition_finished?(new_pb_state, state.playback.pending_state) do
-      finish_pids_transition(state, pid)
-    else
-      {:ok, state}
+  def child_playback_changed(pid, child_pb_state, state) do
+    child = child_by_pid(pid, state)
+    %{playback: playback} = state
+
+    cond do
+      playback.pending_state == nil and playback.state == child_pb_state ->
+        state = put_in(state, [:children, child, :playback_synced?], true)
+        {:ok, state}
+
+      playback.pending_state == child_pb_state ->
+        state = put_in(state, [:children, child, :playback_synced?], true)
+        maybe_finish_playback_transition(state)
+
+      true ->
+        {:ok, state}
     end
   end
 
-  defp no_child_in_transition?(state),
-    do: ChildrenModel.all?(state, &(not &1.pending?))
-
-  defp transition_finished?(pending_state, new_state)
-  defp transition_finished?(pb_state, pb_state), do: true
-  defp transition_finished?(_pending_state, _new_state), do: false
-
-  # Child was removed
   @spec handle_child_death(child_pid :: pid(), reason :: atom(), state :: Component.state_t()) ::
           {:ok, Component.state_t()}
   def handle_child_death(pid, :normal, state) do
-    {:ok, state} = finish_pids_transition(state, pid)
-
-    new_children =
-      state
-      |> ChildrenModel.get_children()
-      |> Enum.filter(fn {_name, entry} -> entry.pid != pid end)
-      |> Enum.into(%{})
-
-    {:ok, %{state | children: new_children}}
-  end
-
-  defp finish_pids_transition(state, pid) do
-    state =
-      state
-      |> ChildrenModel.update_children(fn
-        %{pid: ^pid} = child -> %{child | pending?: false}
-        child -> child
-      end)
-
-    # If we suspended playback state change and there are no pending children
-    # this means we want to continue the change for the parent.
-    if PlaybackHandler.suspended?(state) and no_child_in_transition?(state) do
-      PlaybackHandler.continue_playback_change(__MODULE__, state)
-    else
-      {:ok, state}
-    end
+    child = child_by_pid(pid, state)
+    state = Bunch.Access.delete_in(state, [:children, child])
+    maybe_finish_playback_transition(state)
   end
 
   @spec handle_stream_management_event(atom, Child.name_t(), Pad.ref_t(), Parent.state_t()) ::
@@ -187,6 +156,25 @@ defmodule Membrane.Core.Parent.LifecycleController do
     Bunch.KVEnum.each_value(state.children, &Message.send(&1.pid, :log_metadata, metadata))
 
     {:ok, %{state | children_log_metadata: children_log_metadata}}
+  end
+
+  defp maybe_finish_playback_transition(state) do
+    all_children_in_sync? = ChildrenModel.all?(state, & &1.playback_synced?)
+
+    if PlaybackHandler.suspended?(state) and all_children_in_sync? do
+      PlaybackHandler.continue_playback_change(__MODULE__, state)
+    else
+      {:ok, state}
+    end
+  end
+
+  defp child_by_pid(pid, state) do
+    {child_name, _child_data} =
+      state
+      |> ChildrenModel.get_children()
+      |> Enum.find(fn {_name, entry} -> entry.pid == pid end)
+
+    child_name
   end
 
   defp get_callback_action_handler(%Core.Pipeline.State{}), do: Core.Pipeline.ActionHandler

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -5,7 +5,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
 
   alias Membrane.Core.{Parent, Pipeline, TimerController}
   alias Membrane.Core.Message
-  alias Membrane.Core.Parent.LifecycleController
+  alias Membrane.Core.Parent.{ChildLifeController, LifecycleController}
 
   require Membrane.Core.Message
 
@@ -16,7 +16,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
         Message.new(:playback_state_changed, [pid, new_playback_state]),
         state
       ) do
-    LifecycleController.child_playback_changed(pid, new_playback_state, state)
+    ChildLifeController.child_playback_changed(pid, new_playback_state, state)
     |> noreply(state)
   end
 
@@ -52,7 +52,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   def handle_message({:DOWN, _ref, :process, child_pid, reason}, state) do
-    LifecycleController.handle_child_death(child_pid, reason, state)
+    ChildLifeController.handle_child_death(child_pid, reason, state)
     |> noreply(state)
   end
 

--- a/lib/membrane/core/playback_handler.ex
+++ b/lib/membrane/core/playback_handler.ex
@@ -149,7 +149,7 @@ defmodule Membrane.Core.PlaybackHandler do
     handler_res =
       handler.handle_playback_state_changed(
         old_playback.state,
-        old_playback.pending_state,
+        new_playback.state,
         state
       )
 
@@ -165,10 +165,15 @@ defmodule Membrane.Core.PlaybackHandler do
     end
   end
 
-  defp maybe_notify_controller(handler, %{controlling_pid: controlling_pid} = state)
+  defp maybe_notify_controller(
+         handler,
+         %{
+           controlling_pid: controlling_pid,
+           playback: %{state: playback_state, target_state: playback_state}
+         }
+       )
        when not is_nil(controlling_pid),
-       do:
-         handler.notify_controller(:playback_changed, state.playback.state, state.controlling_pid)
+       do: handler.notify_controller(:playback_changed, playback_state, controlling_pid)
 
   defp maybe_notify_controller(_handler, _state), do: :ok
 


### PR DESCRIPTION
Fixes #104 and another bug: a child spawned during parent playback change remained in the playback state the parent was at the moment of spawning, instead of continuing the change with the parent

Fixes #214