### PR TITLE
Handle delay supply fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# config directory
-config/
 # End of https://www.gitignore.io/api/c,vim,linux,macos,elixir,windows,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-
+# config directory
+config/
 # End of https://www.gitignore.io/api/c,vim,linux,macos,elixir,windows,visualstudiocode

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -9,7 +9,7 @@ defmodule Membrane.Core.Element.ActionHandler do
   import Membrane.Pad, only: [is_pad_ref: 1]
 
   alias Membrane.{ActionError, Buffer, Caps, CallbackError, Event, Notification, Pad}
-  alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
+  alias Membrane.Core.Element.{DemandHandler, LifecycleController, DemandController, State}
   alias Membrane.Core.{Events, Message, PlaybackHandler, TimerController}
   alias Membrane.Core.Child.PadModel
   alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
@@ -142,11 +142,11 @@ defmodule Membrane.Core.Element.ActionHandler do
   defp do_handle_action(
          {:demand, {pad_ref, size}},
          cb,
-         params,
+         _params,
          %State{type: type} = state
        )
        when is_pad_ref(pad_ref) and is_demand_size(size) and type in [:sink, :filter] do
-    supply_demand(pad_ref, size, cb, params[:supplying_demand?] || false, state)
+    supply_demand(pad_ref, size, cb, state)
   end
 
   defp do_handle_action({:start_timer, {id, interval, clock}}, _cb, _params, state) do
@@ -326,7 +326,6 @@ defmodule Membrane.Core.Element.ActionHandler do
           Pad.ref_t(),
           Action.demand_size_t(),
           callback :: atom,
-          currently_supplying? :: boolean,
           State.t()
         ) :: State.stateful_try_t()
 
@@ -334,14 +333,13 @@ defmodule Membrane.Core.Element.ActionHandler do
          _pad_ref,
          _size,
          callback,
-         _currently_supplying?,
          %State{playback: %{state: playback_state}} = state
        )
        when playback_state != :playing and callback != :handle_prepared_to_playing do
     {{:error, {:playback_state, playback_state}}, state}
   end
 
-  defp supply_demand(pad_ref, 0, callback, _currently_supplying?, state) do
+  defp supply_demand(pad_ref, 0, callback, state) do
     Membrane.Logger.debug_verbose("""
     Ignoring demand of size of 0 requested by callback #{inspect(callback)}
     on pad #{inspect(pad_ref)}.
@@ -350,20 +348,17 @@ defmodule Membrane.Core.Element.ActionHandler do
     {:ok, state}
   end
 
-  defp supply_demand(_pad_ref, size, _callback, _currently_supplying?, state)
+  defp supply_demand(_pad_ref, size, _callback, state)
        when is_integer(size) and size < 0 do
     {{:error, :negative_demand}, state}
   end
 
-  defp supply_demand(pad_ref, size, _callback, currently_supplying?, state) do
+  defp supply_demand(pad_ref, size, _callback, state) do
     withl data: {:ok, pad_data} <- PadModel.get_data(state, pad_ref),
           dir: %{direction: :input} <- pad_data,
           mode: %{mode: :pull} <- pad_data,
           update: {:ok, state} <- DemandHandler.update_demand(pad_ref, size, state) do
-      supply_mode = if currently_supplying?, do: :async, else: :sync
-      state = DemandHandler.delay_supply(pad_ref, supply_mode, state)
-
-      {:ok, state}
+      DemandHandler.supply_demand(pad_ref, state)
     else
       data: {:error, reason} -> {{:error, reason}, state}
       dir: %{direction: dir} -> {{:error, {:invalid_pad_dir, pad_ref, dir}}, state}
@@ -377,7 +372,16 @@ defmodule Membrane.Core.Element.ActionHandler do
     withl data: {:ok, pad_data} <- PadModel.get_data(state, out_ref),
           dir: %{direction: :output} <- pad_data,
           mode: %{mode: :pull} <- pad_data do
-      state = DemandHandler.delay_redemand(out_ref, state)
+      state =
+        case state do
+          %State{supplying_demand?: true} ->
+            DemandHandler.delay_redemand(out_ref, state)
+
+          _not_supplying_demand ->
+            {:ok, state} = DemandController.handle_demand(out_ref, 0, state)
+            state
+        end
+
       {:ok, state}
     else
       data: {:error, reason} -> {{:error, reason}, state}

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -372,17 +372,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     withl data: {:ok, pad_data} <- PadModel.get_data(state, out_ref),
           dir: %{direction: :output} <- pad_data,
           mode: %{mode: :pull} <- pad_data do
-      state =
-        case state do
-          %State{supplying_demand?: true} ->
-            DemandHandler.delay_redemand(out_ref, state)
-
-          _not_supplying_demand ->
-            {:ok, state} = DemandController.handle_demand(out_ref, 0, state)
-            state
-        end
-
-      {:ok, state}
+      DemandHandler.handle_redemand(out_ref, state)
     else
       data: {:error, reason} -> {{:error, reason}, state}
       dir: %{direction: dir} -> {{:error, {:invalid_pad_dir, out_ref, dir}}, state}

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -9,7 +9,7 @@ defmodule Membrane.Core.Element.ActionHandler do
   import Membrane.Pad, only: [is_pad_ref: 1]
 
   alias Membrane.{ActionError, Buffer, Caps, CallbackError, Event, Notification, Pad}
-  alias Membrane.Core.Element.{DemandHandler, LifecycleController, DemandController, State}
+  alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
   alias Membrane.Core.{Events, Message, PlaybackHandler, TimerController}
   alias Membrane.Core.Child.PadModel
   alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -136,8 +136,7 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   def supply_demand(pad_ref, state) do
     with {:ok, state} <- do_supply_demand(pad_ref, %State{state | supplying_demand?: true}) do
-      {:ok, state} = handle_delayed_demands(%State{state | supplying_demand?: false})
-      {:ok, %State{state | supplying_demand?: false}}
+      handle_delayed_demands(%State{state | supplying_demand?: false})
     end
   end
 

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -100,18 +100,12 @@ defmodule Membrane.Core.Element.DemandHandler do
     [{pad_ref, action}] = del_dem |> Enum.take_random(1)
     state = %State{state | delayed_demands: del_dem |> MapSet.delete({pad_ref, action})}
 
-    res =
-      case action do
-        :supply ->
-          Message.self(:invoke_supply_demand, pad_ref)
-          {:ok, state}
+    case action do
+      :supply ->
+        supply_demand(pad_ref, state)
 
-        :redemand ->
-          DemandController.handle_demand(pad_ref, 0, state)
-      end
-
-    with {:ok, state} <- res do
-      handle_delayed_demands(state)
+      :redemand ->
+        DemandController.handle_demand(pad_ref, 0, state)
     end
   end
 
@@ -146,7 +140,7 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   def supply_demand(pad_ref, state) do
     with {:ok, state} <- do_supply_demand(pad_ref, %State{state | supplying_demand?: true}) do
-      {:ok, state} = handle_delayed_demands(state)
+      {:ok, state} = handle_delayed_demands(%State{state | supplying_demand?: false})
       {:ok, %State{state | supplying_demand?: false}}
     end
   end

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -5,7 +5,7 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   use Bunch
 
-  alias Membrane.Core.{InputBuffer, Message}
+  alias Membrane.Core.InputBuffer
   alias Membrane.Core.Child.PadModel
 
   alias Membrane.Core.Element.{
@@ -21,8 +21,6 @@ defmodule Membrane.Core.Element.DemandHandler do
   require Membrane.Core.Child.PadModel
   require Membrane.Core.Message
   require Membrane.Logger
-
-  @empty MapSet.new()
 
   @doc """
   Updates demand on the given input pad that should be supplied by future calls
@@ -68,7 +66,8 @@ defmodule Membrane.Core.Element.DemandHandler do
   end
 
   @spec handle_delayed_demands(State.t()) :: State.stateful_try_t()
-  def handle_delayed_demands(%State{delayed_demands: del_dem} = state) when del_dem == %MapSet{} do
+  def handle_delayed_demands(%State{delayed_demands: del_dem} = state)
+      when del_dem == %MapSet{} do
     {:ok, state}
   end
 

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -122,6 +122,23 @@ defmodule Membrane.Core.Element.DemandHandler do
   end
 
   @doc """
+  Called when redemand action was returned.
+    * If element is currently supplying demand it means
+      that after finishing supply_demand it will call handle_delayed_demands so redemand is delayed.
+    * If element is currently not supplying demand (it's always the case for source) handle_demand is
+      invoked right away, and it will invoke handle_demand callback, which will probably return :redemand
+      and :buffers and in that way source will synchronously supply demand.
+  """
+  @spec handle_redemand(Pad.ref_t(), State.t()) :: {:ok, State.t()}
+  def handle_redemand(pad_ref, %State{supplying_demand?: true} = state) do
+    {:ok, delay_redemand(pad_ref, state)}
+  end
+
+  def handle_redemand(pad_ref, state) do
+    DemandController.handle_demand(pad_ref, 0, state)
+  end
+
+  @doc """
   Based on the demand on the given pad takes InputBuffer contents
   and passes it to proper controllers.
   """

--- a/lib/membrane/core/element/message_dispatcher.ex
+++ b/lib/membrane/core/element/message_dispatcher.ex
@@ -33,14 +33,10 @@ defmodule Membrane.Core.Element.MessageDispatcher do
     result =
       withl handle:
               {:ok, {res, state}} <-
-                message |> do_handle_message(mode, state) |> Bunch.stateful_try_with_status(),
-            demands: {:ok, state} <- DemandHandler.handle_delayed_demands(state) do
+                message |> do_handle_message(mode, state) |> Bunch.stateful_try_with_status() do
         {res, state}
       else
         handle: {_error, {{:error, reason}, state}} ->
-          handle_message_error(message, mode, reason, state)
-
-        demands: {{:error, reason}, state} ->
           handle_message_error(message, mode, reason, state)
       end
 

--- a/lib/membrane/core/element/state.ex
+++ b/lib/membrane/core/element/state.ex
@@ -30,6 +30,7 @@ defmodule Membrane.Core.Element.State do
           parent_monitor: reference() | nil,
           playback: Playback.t(),
           playback_buffer: PlaybackBuffer.t(),
+          supplying_demand?: boolean(),
           delayed_demands: %{{Pad.ref_t(), :supply | :redemand} => :sync | :async},
           synchronization: %{
             timers: %{Timer.id_t() => Timer.t()},
@@ -51,6 +52,7 @@ defmodule Membrane.Core.Element.State do
     :parent_monitor,
     :playback,
     :playback_buffer,
+    :supplying_demand?,
     :delayed_demands,
     :synchronization
   ]
@@ -77,6 +79,7 @@ defmodule Membrane.Core.Element.State do
       parent_monitor: options[:parent_monitor],
       playback: %Playback{},
       playback_buffer: PlaybackBuffer.new(),
+      supplying_demand?: false,
       delayed_demands: %{},
       synchronization: %{
         parent_clock: options.parent_clock,

--- a/lib/membrane/core/element/state.ex
+++ b/lib/membrane/core/element/state.ex
@@ -31,7 +31,7 @@ defmodule Membrane.Core.Element.State do
           playback: Playback.t(),
           playback_buffer: PlaybackBuffer.t(),
           supplying_demand?: boolean(),
-          delayed_demands: %{{Pad.ref_t(), :supply | :redemand} => :sync | :async},
+          delayed_demands: MapSet.t({Pad.ref_t(), :supply | :redemand}),
           synchronization: %{
             timers: %{Timer.id_t() => Timer.t()},
             parent_clock: Clock.t(),
@@ -80,7 +80,7 @@ defmodule Membrane.Core.Element.State do
       playback: %Playback{},
       playback_buffer: PlaybackBuffer.new(),
       supplying_demand?: false,
-      delayed_demands: %{},
+      delayed_demands: MapSet.new(),
       synchronization: %{
         parent_clock: options.parent_clock,
         timers: %{},

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -52,7 +52,8 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   def handle_message({:DOWN, _ref, :process, pid, reason} = message, state) do
-    with {{:ok, result}, state} <- ChildLifeController.maybe_handle_child_death(pid, reason, state) do
+    with {{:ok, result}, state} <-
+           ChildLifeController.maybe_handle_child_death(pid, reason, state) do
       case result do
         :child -> {:ok, state}
         :not_child -> LifecycleController.handle_other(message, state)

--- a/mix.exs
+++ b/mix.exs
@@ -109,7 +109,7 @@ defmodule Membrane.Mixfile do
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.4", only: :dev, runtime: false},
-      {:espec, "~> 1.8", only: :test},
+      {:espec, "~> 1.8.3", only: :test},
       {:excoveralls, "~> 0.11", only: :test},
       {:qex, "~> 0.3"},
       {:telemetry, "~> 0.4"},

--- a/test/membrane/core/element/action_handler_test.exs
+++ b/test/membrane/core/element/action_handler_test.exs
@@ -47,7 +47,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         state = %{state | playback: %Playback{state: playback}, supplying_demand?: true}
         assert {:ok, state} = @module.handle_action({:demand, {:input, 10}}, callback, %{}, state)
         assert state.pads.data.input.demand == 10
-        assert %{{:input, :supply} => :async} == state.delayed_demands
+        assert MapSet.new([{:input, :supply}]) == state.delayed_demands
       end)
 
       state = %{state | playback: %Playback{state: :playing}}
@@ -61,7 +61,7 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
                )
 
       assert state.pads.data.input.demand == 10
-      assert %{{:input, :supply} => :async} == state.delayed_demands
+      assert MapSet.new([{:input, :supply}]) == state.delayed_demands
     end
 
     test "returning error on invalid constraints", %{state: state} do
@@ -507,8 +507,8 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
         )
 
       assert {:ok, new_state} = result
-      assert %{new_state | delayed_demands: %{}} == state
-      assert new_state.delayed_demands[{:output, :redemand}] == :sync
+      assert %{new_state | delayed_demands: MapSet.new()} == state
+      assert MapSet.member?(new_state.delayed_demands, {:output, :redemand}) == true
     end
   end
 
@@ -551,8 +551,8 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
       assert_received Message.new(:notification, [:elem_name, :a])
       assert_received Message.new(:notification, [:elem_name, :b])
       assert {:ok, new_state} = result
-      assert %{new_state | delayed_demands: %{}} == state
-      assert new_state.delayed_demands[{:output, :redemand}] == :sync
+      assert %{new_state | delayed_demands: MapSet.new()} == state
+      assert MapSet.member?(new_state.delayed_demands, {:output, :redemand}) == true
     end
 
     test "when two :redemand actions are last", %{state: state} do
@@ -569,8 +569,8 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
       assert_received Message.new(:notification, [:elem_name, :a])
       assert_received Message.new(:notification, [:elem_name, :b])
       assert {:ok, new_state} = result
-      assert %{new_state | delayed_demands: %{}} == state
-      assert new_state.delayed_demands[{:output, :redemand}] == :sync
+      assert %{new_state | delayed_demands: MapSet.new()} == state
+      assert MapSet.member?(new_state.delayed_demands, {:output, :redemand}) == true
     end
 
     test "when :redemand is not the last action", %{state: state} do


### PR DESCRIPTION
- Removes necessity of calling `DemandHandler.handle_delayed_demands()` after receiving a message.
- Replaces `delayed_demands Map` with `delayed_demands Set` after getting rid of sync/async delayed demand types