### PR TITLE
pass messages not from child to handle_other

### DIFF
--- a/lib/membrane/core/bin/state.ex
+++ b/lib/membrane/core/bin/state.ex
@@ -11,6 +11,7 @@ defmodule Membrane.Core.Bin.State do
   alias Membrane.Core.{Playback, Timer}
   alias Membrane.Core.Bin.LinkingBuffer
   alias Membrane.Core.Child.PadModel
+  alias Membrane.Core.Parent.Link
   alias Membrane.Core.Parent.ChildrenModel
   alias Membrane.{Child, Clock, Sync}
 
@@ -24,6 +25,7 @@ defmodule Membrane.Core.Bin.State do
           watcher: pid | nil,
           controlling_pid: pid | nil,
           linking_buffer: LinkingBuffer.t(),
+          links: [Link.t()],
           synchronization: %{
             timers: %{Timer.id_t() => Timer.t()},
             parent_clock: Clock.t(),
@@ -51,6 +53,7 @@ defmodule Membrane.Core.Bin.State do
                 watcher: nil,
                 controlling_pid: nil,
                 linking_buffer: LinkingBuffer.new(),
-                children_log_metadata: []
+                children_log_metadata: [],
+                links: []
               ]
 end

--- a/lib/membrane/core/child/pad_controller.ex
+++ b/lib/membrane/core/child/pad_controller.ex
@@ -330,25 +330,19 @@ defmodule Membrane.Core.Child.PadController do
     %{direction: direction, availability: availability} = PadModel.get_data!(state, ref)
     name = Pad.name_by_ref(ref)
 
-    cond do
-      Pad.availability_mode(availability) == :dynamic and Pad.is_public_name(name) ->
-        context =
-          Component.callback_context_generator(:child, PadRemoved, state, direction: direction)
+    if Pad.availability_mode(availability) == :dynamic and Pad.is_public_name(name) do
+      context =
+        Component.callback_context_generator(:child, PadRemoved, state, direction: direction)
 
-        CallbackHandler.exec_and_handle_callback(
-          :handle_pad_removed,
-          get_callback_action_handler(state),
-          %{context: context},
-          [ref],
-          state
-        )
-
-      Pad.availability_mode(availability) == :static and Pad.is_public_name(name) and
-          state.playback.state in [:playing, :prepared] ->
-        raise("Public static pad #{name} unlinked")
-
-      true ->
-        {:ok, state}
+      CallbackHandler.exec_and_handle_callback(
+        :handle_pad_removed,
+        get_callback_action_handler(state),
+        %{context: context},
+        [ref],
+        state
+      )
+    else
+      {:ok, state}
     end
   end
 

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -149,14 +149,15 @@ defmodule Membrane.Core.Parent.ChildLifeController do
   @spec handle_child_death(child_pid :: pid(), reason :: atom(), state :: Parent.state_t()) ::
           {:ok | {:error, :not_child}, Parent.state_t()}
   def handle_child_death(pid, :normal, state) do
-    with {:ok, child_name} <- child_by_pid(pid, state),
-         state = Bunch.Access.delete_in(state, [:children, child_name]),
-         state = remove_child_links(child_name, state) do
+    with {:ok, child_name} <- child_by_pid(pid, state) do
+      state = Bunch.Access.delete_in(state, [:children, child_name])
+      state = remove_child_links(child_name, state)
+
       LifecycleController.maybe_finish_playback_transition(state)
     else
       {:error, :not_child} ->
         raise Membrane.PipelineError,
-              "Tried to handle child death that wasn't a child of that pipeline."
+              "Tried to handle death of process that wasn't a child of that pipeline."
     end
   end
 
@@ -171,7 +172,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     else
       {:error, :not_member} ->
         raise Membrane.PipelineError,
-              "Child  that was not a member of a group killed with :membrane_crash_group_kill."
+              "Child that was not a member of any crash group killed with :membrane_crash_group_kill."
     end
   end
 

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -54,7 +54,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
 
     case crash_group do
       %CrashGroup{} -> {:ok, crash_group}
-      nil -> :error
+      nil -> {:error, :not_member}
     end
   end
 end

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -52,12 +52,10 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   def handle_message({:DOWN, _ref, :process, pid, reason} = message, state) do
-    with {{:ok, result}, state} <-
-           ChildLifeController.maybe_handle_child_death(pid, reason, state) do
-      case result do
-        :child -> {:ok, state}
-        :not_child -> LifecycleController.handle_other(message, state)
-      end
+    if is_child?(pid, state) do
+      ChildLifeController.handle_child_death(pid, reason, state)
+    else
+      LifecycleController.handle_other(message, state)
     end
     |> noreply(state)
   end
@@ -70,6 +68,13 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   defp inform_parent(state, msg, msg_params) do
     if not pipeline?(state) and state.watcher,
       do: Message.send(state.watcher, msg, [state.name | msg_params])
+  end
+
+  defp is_child?(pid, state) do
+    case Enum.find(state.children, fn {_name, entry} -> entry.pid == pid end) do
+      nil -> false
+      _ -> true
+    end
   end
 
   defp pipeline?(%Pipeline.State{}), do: true

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -73,7 +73,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   defp is_child?(pid, state) do
     case Enum.find(state.children, fn {_name, entry} -> entry.pid == pid end) do
       nil -> false
-      _ -> true
+      _child -> true
     end
   end
 

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -70,7 +70,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
       do: Message.send(state.watcher, msg, [state.name | msg_params])
   end
 
-  defp is_child?(pid, state) do
+  defp is_child_pid?(pid, state) do
     case Enum.find(state.children, fn {_name, entry} -> entry.pid == pid end) do
       nil -> false
       _child -> true

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -71,10 +71,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   defp is_child_pid?(pid, state) do
-    case Enum.find(state.children, fn {_name, entry} -> entry.pid == pid end) do
-      nil -> false
-      _child -> true
-    end
+    Enum.any?(state.children, fn {_name, entry} -> entry.pid == pid end) 
   end
 
   defp pipeline?(%Pipeline.State{}), do: true

--- a/lib/membrane/core/parent/message_dispatcher.ex
+++ b/lib/membrane/core/parent/message_dispatcher.ex
@@ -52,7 +52,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   def handle_message({:DOWN, _ref, :process, pid, reason} = message, state) do
-    if is_child?(pid, state) do
+    if is_child_pid?(pid, state) do
       ChildLifeController.handle_child_death(pid, reason, state)
     else
       LifecycleController.handle_other(message, state)
@@ -71,7 +71,7 @@ defmodule Membrane.Core.Parent.MessageDispatcher do
   end
 
   defp is_child_pid?(pid, state) do
-    Enum.any?(state.children, fn {_name, entry} -> entry.pid == pid end) 
+    Enum.any?(state.children, fn {_name, entry} -> entry.pid == pid end)
   end
 
   defp pipeline?(%Pipeline.State{}), do: true

--- a/test/membrane/core/child/pad_controller_test.exs
+++ b/test/membrane/core/child/pad_controller_test.exs
@@ -89,29 +89,11 @@ defmodule Membrane.Core.Child.PadControllerTest do
       refute new_state.pads.data |> Map.has_key?(:output)
     end
 
-    test "for public static output pad (playing)" do
-      state = prepare_static_state(TrivialFilter, :element, :output, :playing)
-      assert state.pads.data |> Map.has_key?(:output)
-
-      assert_raise RuntimeError, ~r/Public static pad .* unlinked/, fn ->
-        @module.handle_unlink(:output, state)
-      end
-    end
-
     test "for public static input pad (stopped)" do
       state = prepare_static_state(TrivialSink, :element, :input, :stopped)
       assert state.pads.data |> Map.has_key?(:input)
       assert {:ok, new_state} = @module.handle_unlink(:input, state)
       refute new_state.pads.data |> Map.has_key?(:input)
-    end
-
-    test "for public static input pad (playing)" do
-      state = prepare_static_state(TrivialSink, :element, :input, :playing)
-      assert state.pads.data |> Map.has_key?(:input)
-
-      assert_raise RuntimeError, ~r/Public static pad .* unlinked/, fn ->
-        @module.handle_unlink(:input, state)
-      end
     end
 
     test "for dynamic input pad" do


### PR DESCRIPTION
Fix the issue of handling `:DOWN` messages from processes that are not children of pipeline. This PR makes `develop` to work properly when crash groups are not used. Crash groups are yet to be debugged. 