### PR TITLE
fix test

### DIFF
--- a/spec/membrane/core/element/state_spec.exs
+++ b/spec/membrane/core/element/state_spec.exs
@@ -30,7 +30,8 @@ defmodule Membrane.Core.Element.StateSpec do
              controlling_pid: nil,
              playback: %Playback{},
              playback_buffer: PlaybackBuffer.new(),
-             delayed_demands: %{},
+             supplying_demand?: false,
+             delayed_demands: MapSet.new(),
              synchronization: %{
                timers: %{},
                clock: nil,


### PR DESCRIPTION
Other two tests are fixed in the second PR as they involve this `public static pad unlinked` rise, which we've decided to remove. 