### PR TITLE
Pipeline handle group down

### DIFF
--- a/lib/membrane/bin/callback_context/crash_group_down.ex
+++ b/lib/membrane/bin/callback_context/crash_group_down.ex
@@ -1,0 +1,8 @@
+defmodule Membrane.Bin.CallbackContext.CrashGroupDown do
+  @moduledoc """
+  Structure representing a context that is passed to the pipeline
+  when a crash group is down.
+  """
+  use Membrane.Core.Bin.CallbackContext,
+    members: [pid()]
+end

--- a/lib/membrane/bin/callback_context/crash_group_down.ex
+++ b/lib/membrane/bin/callback_context/crash_group_down.ex
@@ -4,5 +4,5 @@ defmodule Membrane.Bin.CallbackContext.CrashGroupDown do
   when a crash group is down.
   """
   use Membrane.Core.Bin.CallbackContext,
-    members: [pid()]
+    members: [Membrane.Child.name_t()]
 end

--- a/lib/membrane/bin/callback_context/pad_added.ex
+++ b/lib/membrane/bin/callback_context/pad_added.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Bin.CallbackContext.PadAdded do
   @moduledoc """
-  Structure representing a context that is passed to the bin when
+  Structure representing a context that is passed to the bin
   when a new dynamic pad instance added is created
   """
   use Membrane.Core.Bin.CallbackContext,

--- a/lib/membrane/core/callback_handler.ex
+++ b/lib/membrane/core/callback_handler.ex
@@ -67,8 +67,9 @@ defmodule Membrane.Core.CallbackHandler do
         state
       )
       when is_map(handler_params) do
-    result = callback |> exec_callback(args, handler_params, state)
-    result |> handle_callback_result(callback, handler_module, handler_params, state)
+    result = exec_callback(callback, args, handler_params, state)
+
+    handle_callback_result(result, callback, handler_module, handler_params, state)
   end
 
   @spec exec_and_handle_splitted_callback(

--- a/lib/membrane/core/callback_handler.ex
+++ b/lib/membrane/core/callback_handler.ex
@@ -138,6 +138,7 @@ defmodule Membrane.Core.CallbackHandler do
         ) :: Type.stateful_try_t(state_t)
   defp handle_callback_result(cb_result, callback, handler_module, handler_params, state) do
     {result, new_internal_state} = cb_result
+
     state = Map.put(state, :internal_state, new_internal_state)
 
     with {{:ok, actions}, state} <- {result, state},

--- a/lib/membrane/core/callback_handler.ex
+++ b/lib/membrane/core/callback_handler.ex
@@ -138,12 +138,11 @@ defmodule Membrane.Core.CallbackHandler do
         ) :: Type.stateful_try_t(state_t)
   defp handle_callback_result(cb_result, callback, handler_module, handler_params, state) do
     {result, new_internal_state} = cb_result
-    state = state |> Map.put(:internal_state, new_internal_state)
+    state = Map.put(state, :internal_state, new_internal_state)
 
     with {{:ok, actions}, state} <- {result, state},
          {:ok, state} <-
-           actions
-           |> exec_handle_actions(callback, handler_module, handler_params, state) do
+           exec_handle_actions(actions, callback, handler_module, handler_params, state) do
       {:ok, state}
     end
   end
@@ -151,7 +150,7 @@ defmodule Membrane.Core.CallbackHandler do
   @spec exec_handle_actions(list, callback :: atom, module, handler_params_t, state_t) ::
           Type.stateful_try_t(state_t)
   defp exec_handle_actions(actions, callback, handler_module, handler_params, state) do
-    with {:ok, state} <- actions |> handler_module.handle_actions(callback, handler_params, state) do
+    with {:ok, state} <- handler_module.handle_actions(actions, callback, handler_params, state) do
       {:ok, state}
     else
       {{:error, reason}, state} ->

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -180,18 +180,17 @@ defmodule Membrane.Core.Parent.ChildLifeController do
         raise Membrane.PipelineError,
               "Tried to handle death of process that wasn't a child of that pipeline."
 
-      {:error, :not_member} ->
-        if reason == {:shutdown, :membrane_crash_group_kill} do
-          raise Membrane.PipelineError,
-                "Child that was not a member of any crash group killed with :membrane_crash_group_kill."
-        else
-          Membrane.Logger.debug("""
-          Pipeline child crashed but was not a member of any crash group.
-          Terminating.
-          """)
+      {:error, :not_member} when reason == {:shutdown, :membrane_crash_group_kill} ->
+        raise Membrane.PipelineError,
+              "Child that was not a member of any crash group killed with :membrane_crash_group_kill."
 
-          propagate_child_crash(state)
-        end
+      {:error, :not_member} ->
+        Membrane.Logger.debug("""
+        Pipeline child crashed but was not a member of any crash group.
+        Terminating.
+        """)
+
+        propagate_child_crash(state)
     end
   end
 

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -162,10 +162,12 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
   def handle_child_death(pid, {:shutdown, :membrane_crash_group_kill}, state) do
     with {:ok, group} <- CrashGroupHandler.get_group_by_member_pid(pid, state) do
-      state =
+      {result, state} =
         state
         |> CrashGroupHandler.remove_member_of_crash_group(group.name, pid)
         |> CrashGroupHandler.remove_crash_group_if_empty(group.name)
+
+      if result == :removed, do: exec_handle_crash_group_down_callback(group, state)
 
       {:ok, state}
     else
@@ -177,23 +179,12 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
   def handle_child_death(pid, _reason, state) do
     with {:ok, group} <- CrashGroupHandler.get_group_by_member_pid(pid, state) do
-      state =
+      {result, state} =
         crash_all_group_members(group, state)
         |> CrashGroupHandler.remove_member_of_crash_group(group.name, pid)
         |> CrashGroupHandler.remove_crash_group_if_empty(group.name)
 
-      context =
-        Component.callback_context_generator(:parent, CrashGroupDown, state,
-          members: group.members
-        )
-
-      CallbackHandler.exec_and_handle_callback(
-        :handle_crash_group_down,
-        Membrane.Core.Pipeline.ActionHandler,
-        %{context: context},
-        [group.name],
-        state
-      )
+      if result == :removed, do: exec_handle_crash_group_down_callback(group, state)
 
       {:ok, state}
     else
@@ -205,6 +196,19 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
         propagate_child_crash()
     end
+  end
+
+  defp exec_handle_crash_group_down_callback(group, state) do
+    context =
+      Component.callback_context_generator(:parent, CrashGroupDown, state, members: group.members)
+
+    CallbackHandler.exec_and_handle_callback(
+      :handle_crash_group_down,
+      Membrane.Core.Pipeline.ActionHandler,
+      %{context: context},
+      [group.name],
+      state
+    )
   end
 
   # called when process was a member of a crash group

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -183,7 +183,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
       CallbackHandler.exec_and_handle_callback(
           :handle_crash_group_down,
-          Core.Parent.Pipeline.ActionHandler,
+          Membrane.Core.Pipeline.ActionHandler,
           %{context: fn _state -> group.members end},
           [group.name],
           state

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -235,7 +235,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
   end
 
   defp crash_all_group_members(_crash_group, state), do: state
-  
+
   # called when a dead child was not a member of any crash group
   defp propagate_child_crash() do
     Membrane.Logger.debug("""

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -4,7 +4,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
   alias __MODULE__.{StartupHandler, LinkHandler, CrashGroupHandler}
   alias Membrane.ParentSpec
-  alias Membrane.Core.Parent
+  alias Membrane.Core.{Parent, PlaybackHandler, CallbackHandler}
 
   alias Membrane.Core.Parent.{
     ChildEntryParser,
@@ -14,8 +14,6 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     ChildLifeController,
     CrashGroup
   }
-
-  alias Membrane.Core.PlaybackHandler
 
   require Membrane.Logger
   require Membrane.Bin
@@ -180,6 +178,14 @@ defmodule Membrane.Core.Parent.ChildLifeController do
         crash_all_group_members(group, state)
         |> CrashGroupHandler.remove_member_of_crash_group(group.name, pid)
         |> CrashGroupHandler.remove_crash_group_if_empty(group.name)
+
+      CallbackHandler.exec_and_handle_callback(
+          :handle_group_down,
+          Core.Parent.Pipeline.ActionHandler,
+          %{},
+          [group.name],
+          state
+        )
 
       {{:ok, :child}, state}
     else

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -200,7 +200,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
   defp exec_handle_crash_group_down_callback(group, state) do
     members_names =
-      Enum.map(group.members, fn member_pid ->
+      Enum.map(group.dead_members, fn member_pid ->
         {:ok, member_name} = child_by_pid(member_pid, state)
         member_name
       end)

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -199,8 +199,14 @@ defmodule Membrane.Core.Parent.ChildLifeController do
   end
 
   defp exec_handle_crash_group_down_callback(group, state) do
+    members_names =
+      Enum.map(group.members, fn member_pid ->
+        {:ok, member_name} = child_by_pid(member_pid, state)
+        member_name
+      end)
+
     context =
-      Component.callback_context_generator(:parent, CrashGroupDown, state, members: group.members)
+      Component.callback_context_generator(:parent, CrashGroupDown, state, members: members_names)
 
     CallbackHandler.exec_and_handle_callback(
       :handle_crash_group_down,

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -173,9 +173,9 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
       if result == :removed do
         exec_handle_crash_group_down_callback(group.name, group.members, state)
+      else
+        {:ok, state}
       end
-
-      {:ok, state}
     else
       {:error, :not_child} ->
         raise Membrane.PipelineError,
@@ -198,9 +198,9 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
       if result == :removed do
         exec_handle_crash_group_down_callback(group.name, group.members, state)
+      else
+        {:ok, state}
       end
-
-      {:ok, state}
     else
       {:error, :not_child} ->
         raise Membrane.PipelineError,

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -8,7 +8,6 @@ defmodule Membrane.Core.Parent.ChildLifeController do
 
   alias Membrane.Core.Parent.{
     ChildEntryParser,
-    ChildLifeController,
     ClockHandler,
     CrashGroup,
     LifecycleController,

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -2,23 +2,23 @@ defmodule Membrane.Core.Parent.ChildLifeController do
   @moduledoc false
   use Bunch
 
-  alias __MODULE__.{StartupHandler, LinkHandler, CrashGroupHandler}
+  alias __MODULE__.{CrashGroupHandler, LinkHandler, StartupHandler}
   alias Membrane.ParentSpec
-  alias Membrane.Core.{Parent, PlaybackHandler, CallbackHandler, Component}
+  alias Membrane.Core.{CallbackHandler, Component, Parent, PlaybackHandler}
 
   alias Membrane.Core.Parent.{
     ChildEntryParser,
-    ClockHandler,
-    LifecycleController,
-    Link,
     ChildLifeController,
-    CrashGroup
+    ClockHandler,
+    CrashGroup,
+    LifecycleController,
+    Link
   }
 
-  require Membrane.Logger
+  require Membrane.Core.Component
   require Membrane.Bin
   require Membrane.Element
-  require Membrane.Core.Component
+  require Membrane.Logger
 
   @spec handle_spec(ParentSpec.t(), Parent.state_t()) ::
           {{:ok, [Membrane.Child.name_t()]}, Parent.state_t()} | no_return

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -180,9 +180,9 @@ defmodule Membrane.Core.Parent.ChildLifeController do
         |> CrashGroupHandler.remove_crash_group_if_empty(group.name)
 
       CallbackHandler.exec_and_handle_callback(
-          :handle_group_down,
+          :handle_crash_group_down,
           Core.Parent.Pipeline.ActionHandler,
-          %{},
+          %{context: fn _state -> group.members end},
           [group.name],
           state
         )

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -23,9 +23,9 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
     %CrashGroup{members: members} = state.crash_groups[group_name]
 
     if members == [] do
-      crash_groups = Bunch.Access.delete_in(state, [:crash_groups, group_name])
+      state = Bunch.Access.delete_in(state, [:crash_groups, group_name])
 
-      {:removed, %{state | crash_groups: crash_groups}}
+      {:removed, state}
     else
       {:not_removed, state}
     end

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -40,6 +40,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
         [:crash_groups, group_name, :members],
         &List.delete(&1, pid)
       )
+      |> Bunch.Access.update_in([:crash_groups, group_name, :dead_members], &[pid | &1])
     else
       state
     end

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -31,8 +31,13 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
             state.crash_groups,
             group_name,
             crash_group,
-            fn %CrashGroup{members: current_children_names, alive_members: current_alive_members} = existing_group ->
-              %{existing_group | members: current_children_names ++ children_names, alive_members: current_alive_members ++ children_pids}
+            fn %CrashGroup{members: current_children_names, alive_members: current_alive_members} =
+                 existing_group ->
+              %{
+                existing_group
+                | members: current_children_names ++ children_names,
+                  alive_members: current_alive_members ++ children_pids
+              }
             end
           )
     }

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -18,26 +18,24 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
     {group_name, mode} = group_spec
 
     state =
-      Bunch.Access.update_in(state, [:crash_groups, group_name], fn maybe_group ->
-        if maybe_group do
+      Bunch.Access.update_in(state, [:crash_groups, group_name], fn
+        %CrashGroup{
+          members: current_children_names,
+          alive_members_pids: current_alive_members
+        } = group ->
           %CrashGroup{
-            members: current_children_names,
-            alive_members_pids: current_alive_members
-          } = maybe_group
-
-          %CrashGroup{
-            maybe_group
+            group
             | members: current_children_names ++ children_names,
               alive_members_pids: current_alive_members ++ children_pids
           }
-        else
+
+        nil ->
           %CrashGroup{
             name: group_name,
             mode: mode,
             members: children_names,
             alive_members_pids: children_pids
           }
-        end
       end)
 
     {:ok, state}

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -17,30 +17,28 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
   def add_crash_group(group_spec, children_names, children_pids, state) do
     {group_name, mode} = group_spec
 
-    crash_group = %CrashGroup{
-      name: group_name,
-      mode: mode,
-      members: children_names,
-      alive_members: children_pids
-    }
+    state =
+      Bunch.Access.update_in(state, [:crash_groups, group_name], fn maybe_group ->
+        if maybe_group do
+          %CrashGroup{
+            members: current_children_names,
+            alive_members_pids: current_alive_members
+          } = maybe_group
 
-    state = %{
-      state
-      | crash_groups:
-          Map.update(
-            state.crash_groups,
-            group_name,
-            crash_group,
-            fn %CrashGroup{members: current_children_names, alive_members: current_alive_members} =
-                 existing_group ->
-              %{
-                existing_group
-                | members: current_children_names ++ children_names,
-                  alive_members: current_alive_members ++ children_pids
-              }
-            end
-          )
-    }
+          %CrashGroup{
+            maybe_group
+            | members: current_children_names ++ children_names,
+              alive_members_pids: current_alive_members ++ children_pids
+          }
+        else
+          %CrashGroup{
+            name: group_name,
+            mode: mode,
+            members: children_names,
+            alive_members_pids: children_pids
+          }
+        end
+      end)
 
     {:ok, state}
   end
@@ -48,9 +46,9 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
   @spec remove_crash_group_if_empty(Pipeline.State.t(), CrashGroup.name_t()) ::
           {:removed | :not_removed, Pipeline.State.t()}
   def remove_crash_group_if_empty(state, group_name) do
-    %CrashGroup{alive_members: alive_members} = state.crash_groups[group_name]
+    %CrashGroup{alive_members_pids: alive_members_pids} = state.crash_groups[group_name]
 
-    if alive_members == [] do
+    if alive_members_pids == [] do
       state = Bunch.Access.delete_in(state, [:crash_groups, group_name])
 
       {:removed, state}
@@ -65,7 +63,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
     if group_name in Map.keys(state.crash_groups) do
       Bunch.Access.update_in(
         state,
-        [:crash_groups, group_name, :alive_members],
+        [:crash_groups, group_name, :alive_members_pids],
         &List.delete(&1, pid)
       )
     else
@@ -78,7 +76,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
     crash_group =
       state.crash_groups
       |> Map.values()
-      |> Enum.find(fn %CrashGroup{alive_members: alive_members_pids} ->
+      |> Enum.find(fn %CrashGroup{alive_members_pids: alive_members_pids} ->
         member_pid in alive_members_pids
       end)
 
@@ -90,14 +88,10 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
 
   @spec set_triggered(Pipeline.State.t(), CrashGroup.name_t(), boolean()) :: Pipeline.State.t()
   def set_triggered(state, group_name, value \\ true) do
-    if group_name in Map.keys(state.crash_groups) do
-      Bunch.Access.put_in(
-        state,
-        [:crash_groups, group_name, :triggered?],
-        value
-      )
-    else
-      state
-    end
+    Bunch.Access.put_in(
+      state,
+      [:crash_groups, group_name, :triggered?],
+      value
+    )
   end
 end

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -24,7 +24,20 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
       alive_members: children_pids
     }
 
-    {:ok, %{state | crash_groups: Map.put(state.crash_groups, group_name, crash_group)}}
+    state = %{
+      state
+      | crash_groups:
+          Map.update(
+            state.crash_groups,
+            group_name,
+            crash_group,
+            fn %CrashGroup{members: current_children_names, alive_members: current_alive_members} = existing_group ->
+              %{existing_group | members: current_children_names ++ children_names, alive_members: current_alive_members ++ children_pids}
+            end
+          )
+    }
+
+    {:ok, state}
   end
 
   @spec remove_crash_group_if_empty(Pipeline.State.t(), CrashGroup.name_t()) ::

--- a/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_handler.ex
@@ -18,21 +18,23 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupHandler do
   end
 
   @spec remove_crash_group_if_empty(Pipeline.State.t(), CrashGroup.name_t()) ::
-          Pipeline.State.t()
+          {:removed | :not_removed, Pipeline.State.t()}
   def remove_crash_group_if_empty(state, group_name) do
-    if state.crash_groups[group_name] == [] do
+    %CrashGroup{members: members} = state.crash_groups[group_name]
+
+    if members == [] do
       crash_groups = Bunch.Access.delete_in(state, [:crash_groups, group_name])
 
-      %{state | crash_groups: crash_groups}
+      {:removed, %{state | crash_groups: crash_groups}}
     else
-      state
+      {:not_removed, state}
     end
   end
 
   @spec remove_member_of_crash_group(Pipeline.State.t(), CrashGroup.name_t(), pid()) ::
           Pipeline.State.t()
   def remove_member_of_crash_group(state, group_name, pid) do
-    if group_name in state.crash_groups do
+    if group_name in Map.keys(state.crash_groups) do
       Bunch.Access.update_in(
         state,
         [:crash_groups, group_name, :members],

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -40,7 +40,9 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
 
   @spec unlink_crash_group(CrashGroup.t(), Parent.state_t()) :: Parent.state_t()
   def unlink_crash_group(crash_group, state) do
-    %CrashGroup{members: members_pids} = crash_group
+    %CrashGroup{members: members_names} = crash_group
+
+    members_pids = Enum.map(state.children, &(elem(&1, 1))) |> Enum.filter(&(&1.name in members_names)) |> Enum.map(&(&1.pid))
 
     links_to_remove =
       Enum.filter(state.links, fn %Link{from: from, to: to} ->

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -42,7 +42,10 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
   def unlink_crash_group(crash_group, state) do
     %CrashGroup{members: members_names} = crash_group
 
-    members_pids = Enum.map(state.children, &(elem(&1, 1))) |> Enum.filter(&(&1.name in members_names)) |> Enum.map(&(&1.pid))
+    members_pids =
+      Enum.map(state.children, &elem(&1, 1))
+      |> Enum.filter(&(&1.name in members_names))
+      |> Enum.map(& &1.pid)
 
     links_to_remove =
       Enum.filter(state.links, fn %Link{from: from, to: to} ->

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -42,20 +42,15 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
   def unlink_crash_group(crash_group, state) do
     %CrashGroup{members: members_names} = crash_group
 
-    members_pids =
-      Enum.map(state.children, &elem(&1, 1))
-      |> Enum.filter(&(&1.name in members_names))
-      |> Enum.map(& &1.pid)
-
     links_to_remove =
       Enum.filter(state.links, fn %Link{from: from, to: to} ->
-        from.pid in members_pids or to.pid in members_pids
+        from.child in members_names or to.child in members_names
       end)
 
     Enum.each(links_to_remove, fn %Link{to: to, from: from} ->
       cond do
-        from.pid not in members_pids -> Message.send(from.pid, :handle_unlink, from.pad_ref)
-        to.pid not in members_pids -> Message.send(to.pid, :handle_unlink, to.pad_ref)
+        from.child not in members_names -> Message.send(from.pid, :handle_unlink, from.pad_ref)
+        to.child not in members_names -> Message.send(to.pid, :handle_unlink, to.pad_ref)
         true -> :ok
       end
     end)

--- a/lib/membrane/core/parent/crash_group.ex
+++ b/lib/membrane/core/parent/crash_group.ex
@@ -13,10 +13,11 @@ defmodule Membrane.Core.Parent.CrashGroup do
   @type t :: %__MODULE__{
           name: name_t(),
           mode: :temporary,
-          members: [pid()],
-          dead_members: [pid()]
+          members: [Membrane.Child.name_t()],
+          alive_members: [pid()],
+          triggered?: boolean()
         }
 
   @enforce_keys [:name, :mode]
-  defstruct @enforce_keys ++ [members: []] ++ [dead_members: []]
+  defstruct @enforce_keys ++ [members: [], alive_members: [], triggered?: false]
 end

--- a/lib/membrane/core/parent/crash_group.ex
+++ b/lib/membrane/core/parent/crash_group.ex
@@ -14,10 +14,10 @@ defmodule Membrane.Core.Parent.CrashGroup do
           name: name_t(),
           mode: :temporary,
           members: [Membrane.Child.name_t()],
-          alive_members: [pid()],
+          alive_members_pids: [pid()],
           triggered?: boolean()
         }
 
   @enforce_keys [:name, :mode]
-  defstruct @enforce_keys ++ [members: [], alive_members: [], triggered?: false]
+  defstruct @enforce_keys ++ [members: [], alive_members_pids: [], triggered?: false]
 end

--- a/lib/membrane/core/parent/crash_group.ex
+++ b/lib/membrane/core/parent/crash_group.ex
@@ -13,9 +13,10 @@ defmodule Membrane.Core.Parent.CrashGroup do
   @type t :: %__MODULE__{
           name: name_t(),
           mode: :temporary,
-          members: [pid()]
+          members: [pid()],
+          dead_members: [pid()]
         }
 
   @enforce_keys [:name, :mode]
-  defstruct @enforce_keys ++ [members: []]
+  defstruct @enforce_keys ++ [members: []] ++ [dead_members: []]
 end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -17,6 +17,7 @@ defmodule Membrane.Pipeline do
   alias __MODULE__.{Action, CallbackContext}
   alias Membrane.{Child, Pad}
   alias Membrane.Core.{CallbackHandler, PlaybackHandler}
+  alias Membrane.Core.Parent.CrashGroup
 
   require Membrane.Logger
 
@@ -166,6 +167,11 @@ defmodule Membrane.Pipeline do
               state :: state_t
             ) :: callback_return_t
 
+  @doc """
+  Callback invoked when crash of the crash group happens.
+  """
+  @callback handle_group_down(group_name :: CrashGroup.name_t(), state :: state_t) :: callback_return_t
+
   @optional_callbacks handle_init: 1,
                       handle_shutdown: 2,
                       handle_stopped_to_prepared: 2,
@@ -178,7 +184,8 @@ defmodule Membrane.Pipeline do
                       handle_element_start_of_stream: 3,
                       handle_element_end_of_stream: 3,
                       handle_notification: 4,
-                      handle_tick: 3
+                      handle_tick: 3,
+                      handle_group_down: 2
 
   @doc """
   Starts the Pipeline based on given module and links it to the current
@@ -442,6 +449,9 @@ defmodule Membrane.Pipeline do
       def handle_notification(notification, element, _ctx, state),
         do: handle_notification(notification, element, state)
 
+      @impl true
+      def handle_group_down(group_name, state), do: {:ok, state}
+
       # DEPRECATED:
 
       # credo:disable-for-lines:21 Credo.Check.Readability.Specs
@@ -491,7 +501,8 @@ defmodule Membrane.Pipeline do
                        handle_spec_started: 3,
                        handle_element_start_of_stream: 3,
                        handle_element_end_of_stream: 3,
-                       handle_notification: 4
+                       handle_notification: 4,
+                       handle_group_down: 2
                      ] ++ deprecated
     end
   end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -502,7 +502,7 @@ defmodule Membrane.Pipeline do
                        handle_element_start_of_stream: 3,
                        handle_element_end_of_stream: 3,
                        handle_notification: 4,
-                       handle_group_down: 2
+                       handle_crash_group_down: 3
                      ] ++ deprecated
     end
   end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -170,7 +170,11 @@ defmodule Membrane.Pipeline do
   @doc """
   Callback invoked when crash of the crash group happens.
   """
-  @callback handle_crash_group_down(group_name :: CrashGroup.name_t(), context :: [pid()], state :: state_t) :: callback_return_t
+  @callback handle_crash_group_down(
+              group_name :: CrashGroup.name_t(),
+              context :: [pid()],
+              state :: state_t
+            ) :: callback_return_t
 
   @optional_callbacks handle_init: 1,
                       handle_shutdown: 2,

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -454,7 +454,9 @@ defmodule Membrane.Pipeline do
         do: handle_notification(notification, element, state)
 
       @impl true
-      def handle_crash_group_down(_group_name, _ctx, state), do: {:ok, state}
+      def handle_crash_group_down(_group_name, _ctx, state) do
+        {:ok, state}
+      end
 
       # DEPRECATED:
 

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -170,7 +170,7 @@ defmodule Membrane.Pipeline do
   @doc """
   Callback invoked when crash of the crash group happens.
   """
-  @callback handle_group_down(group_name :: CrashGroup.name_t(), state :: state_t) :: callback_return_t
+  @callback handle_crash_group_down(group_name :: CrashGroup.name_t(), context :: [pid()], state :: state_t) :: callback_return_t
 
   @optional_callbacks handle_init: 1,
                       handle_shutdown: 2,
@@ -185,7 +185,7 @@ defmodule Membrane.Pipeline do
                       handle_element_end_of_stream: 3,
                       handle_notification: 4,
                       handle_tick: 3,
-                      handle_group_down: 2
+                      handle_crash_group_down: 3
 
   @doc """
   Starts the Pipeline based on given module and links it to the current
@@ -450,7 +450,7 @@ defmodule Membrane.Pipeline do
         do: handle_notification(notification, element, state)
 
       @impl true
-      def handle_group_down(group_name, state), do: {:ok, state}
+      def handle_crash_group_down(_group_name, _ctx, state), do: {:ok, state}
 
       # DEPRECATED:
 

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -172,7 +172,7 @@ defmodule Membrane.Pipeline do
   """
   @callback handle_crash_group_down(
               group_name :: CrashGroup.name_t(),
-              context :: [pid()],
+              context :: CallbackContext.CrashGroupDown.t(),
               state :: state_t
             ) :: callback_return_t
 

--- a/lib/membrane/pipeline/callback_context/crash_group_down.ex
+++ b/lib/membrane/pipeline/callback_context/crash_group_down.ex
@@ -4,5 +4,5 @@ defmodule Membrane.Pipeline.CallbackContext.CrashGroupDown do
   when a crash group is down.
   """
   use Membrane.Core.Pipeline.CallbackContext,
-    members: [pid()]
+    members: [Membrane.Child.name_t()]
 end

--- a/lib/membrane/pipeline/callback_context/crash_group_down.ex
+++ b/lib/membrane/pipeline/callback_context/crash_group_down.ex
@@ -1,0 +1,8 @@
+defmodule Membrane.Pipeline.CallbackContext.CrashGroupDown do
+  @moduledoc """
+  Structure representing a context that is passed to the bin
+  when a crash group is down.
+  """
+  use Membrane.Core.Pipeline.CallbackContext,
+    members: [pid()]
+end

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -374,6 +374,16 @@ defmodule Membrane.Testing.Pipeline do
     )
   end
 
+  @impl true
+  def handle_crash_group_down(group_name, ctx, state) do
+    eval(
+      :handle_crash_group_down,
+      [group_name, ctx],
+      fn -> {:ok, state} end,
+      state
+    )
+  end
+
   defp default_options(%Options{test_process: nil} = options),
     do: %Options{options | test_process: self()}
 

--- a/test/membrane/integration/child_crash_test.exs
+++ b/test/membrane/integration/child_crash_test.exs
@@ -71,7 +71,7 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
   end
 
-  test "Element that is a member of a crash group" do
+  test "Crash two groups one after another" do
     Process.flag(:trap_exit, true)
 
     assert {:ok, pipeline_pid} =
@@ -139,6 +139,20 @@ defmodule Membrane.Integration.ChildCrashTest do
 
     assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
     refute_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 2})
+
+    ChildCrashTest.Pipeline.crash_child(filter_1_2_pid)
+
+    # assert all members of group are dead
+    assert_pid_dead(filter_1_2_pid)
+    assert_pid_dead(filter_2_2_pid)
+    assert_pid_dead(source_2_pid)
+
+    # assert all other members of pipeline and pipeline itself are alive
+    assert_pid_alive(sink_pid)
+    assert_pid_alive(center_filter_pid)
+    assert_pid_alive(pipeline_pid)
+
+    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 2})
   end
 
   defp assert_pid_alive(pid) do

--- a/test/membrane/integration/child_crash_test.exs
+++ b/test/membrane/integration/child_crash_test.exs
@@ -67,6 +67,8 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pid_alive(center_filter_pid)
     assert_pid_alive(sink_pid)
     assert_pid_alive(pipeline_pid)
+
+    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
   end
 
   test "Element that is a member of a crash group" do
@@ -134,6 +136,9 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pid_alive(filter_2_2_pid)
     assert_pid_alive(source_2_pid)
     assert_pid_alive(pipeline_pid)
+
+    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
+    refute_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 2})
   end
 
   defp assert_pid_alive(pid) do

--- a/test/support/child_crash_test/pipeline.ex
+++ b/test/support/child_crash_test/pipeline.ex
@@ -39,6 +39,17 @@ defmodule Membrane.Support.ChildCrashTest.Pipeline do
     {{:ok, spec: spec}, state}
   end
 
+  @impl true
+  def handle_other({:handle_crash_group_called, _group_name}, _ctx, state) do
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_crash_group_down(group_name, _ctx, state) do
+    send(self(), {:handle_crash_group_called, group_name})
+    {:ok, state}
+  end
+
   @spec add_single_source(pid(), any(), any(), any()) :: any()
   def add_single_source(pid, source_name, group \\ nil, source \\ Testing.Source) do
     children = [


### PR DESCRIPTION
* add callback `handle_crash_group_down/3`
* add wrapper in `Membrane.Testing.Pipeline` for that callback
* updated integration tests to verify if callback is being called
* changed syntax from `x |> f(y)` to `f(x, y)` where it was looking bad imo