### PR TITLE
Add OS pid to pipeline name

### DIFF
--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -11,7 +11,7 @@ defmodule Membrane.Core.Pipeline do
 
   @impl GenServer
   def init({module, pipeline_options}) do
-    pipeline_name = "pipeline@#{:erlang.pid_to_list(self())}"
+    pipeline_name = "pipeline@#{System.pid()}@#{:erlang.pid_to_list(self())}"
     :ok = Membrane.ComponentPath.set([pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)
     {:ok, clock} = Clock.start_link(proxy: true)


### PR DESCRIPTION
Adding OS pid to pipeline name solves problem with uniqueness when running applications in parallel on the same device. Resolves issues:
- [Investigate handling more than one pipeline #4](https://github.com/membraneframework/membrane_dashboard/issues/4)
- [Unique violation error when running the same pipeline twice in parallel #5](https://github.com/membraneframework/membrane_timescaledb_reporter/issues/5)
