### PR TITLE
More telemetry events

### DIFF
--- a/lib/membrane/core/element/caps_controller.ex
+++ b/lib/membrane/core/element/caps_controller.ex
@@ -6,15 +6,14 @@ defmodule Membrane.Core.Element.CapsController do
   use Bunch
 
   alias Membrane.{Caps, Pad}
-  alias Membrane.ComponentPath
   alias Membrane.Core.{CallbackHandler, InputBuffer}
   alias Membrane.Core.Child.PadModel
   alias Membrane.Core.Element.{ActionHandler, State}
   alias Membrane.Element.CallbackContext
-  alias Membrane.Telemetry
 
   require Membrane.Core.Child.PadModel
   require Membrane.Logger
+  require Membrane.Telemetry
 
   @doc """
   Handles incoming caps: either stores them in InputBuffer, or executes element callback.
@@ -67,16 +66,6 @@ defmodule Membrane.Core.Element.CapsController do
   end
 
   defp report_caps(log_tag) do
-    :telemetry.execute(
-      Telemetry.metric_event_name(),
-      %{
-        element_path:
-          ComponentPath.get_formatted() <>
-            "/" <> (log_tag || ""),
-        metric: "caps",
-        value: 1
-      },
-      %{}
-    )
+    Membrane.Telemetry.report_metric("caps", 1, log_tag)
   end
 end

--- a/lib/membrane/core/element/caps_controller.ex
+++ b/lib/membrane/core/element/caps_controller.ex
@@ -20,7 +20,7 @@ defmodule Membrane.Core.Element.CapsController do
   """
   @spec handle_caps(Pad.ref_t(), Caps.t(), State.t()) :: State.stateful_try_t()
   def handle_caps(pad_ref, caps, state) do
-    report_caps(inspect(pad_ref))
+    Membrane.Telemetry.report_metric("caps", 1, inspect(pad_ref))
 
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
     data = PadModel.get_data!(state, pad_ref)
@@ -63,9 +63,5 @@ defmodule Membrane.Core.Element.CapsController do
       callback: {{:error, reason}, state} ->
         {{:error, reason}, state}
     end
-  end
-
-  defp report_caps(log_tag) do
-    Membrane.Telemetry.report_metric("caps", 1, log_tag)
   end
 end

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -28,7 +28,7 @@ defmodule Membrane.Core.Element.EventController do
   """
   @spec handle_event(Pad.ref_t(), Event.t(), State.t()) :: State.stateful_try_t()
   def handle_event(pad_ref, event, state) do
-    report_event(inspect(pad_ref))
+    Membrane.Telemetry.report_metric("event", 1, inspect(pad_ref))
 
     pad_data = PadModel.get_data!(state, pad_ref)
 
@@ -171,8 +171,4 @@ defmodule Membrane.Core.Element.EventController do
 
   defp stream_event_to_callback(%Events.StartOfStream{}), do: :handle_start_of_stream
   defp stream_event_to_callback(%Events.EndOfStream{}), do: :handle_end_of_stream
-
-  defp report_event(log_tag) do
-    Membrane.Telemetry.report_metric("event", 1, log_tag)
-  end
 end

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -6,16 +6,15 @@ defmodule Membrane.Core.Element.EventController do
   use Bunch
 
   alias Membrane.{Event, Pad, Sync}
-  alias Membrane.ComponentPath
   alias Membrane.Core.{CallbackHandler, Events, InputBuffer, Message}
   alias Membrane.Core.Child.PadModel
   alias Membrane.Core.Element.{ActionHandler, State}
   alias Membrane.Element.CallbackContext
-  alias Membrane.Telemetry
 
   require Membrane.Core.Child.PadModel
   require Membrane.Core.Message
   require Membrane.Logger
+  require Membrane.Telemetry
 
   @spec handle_start_of_stream(Pad.ref_t(), State.t()) :: State.stateful_try_t()
   def handle_start_of_stream(pad_ref, state) do
@@ -174,16 +173,6 @@ defmodule Membrane.Core.Element.EventController do
   defp stream_event_to_callback(%Events.EndOfStream{}), do: :handle_end_of_stream
 
   defp report_event(log_tag) do
-    :telemetry.execute(
-      Telemetry.metric_event_name(),
-      %{
-        element_path:
-          ComponentPath.get_formatted() <>
-            "/" <> (log_tag || ""),
-        metric: "event",
-        value: 1
-      },
-      %{}
-    )
+    Membrane.Telemetry.report_metric("event", 1, log_tag)
   end
 end

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -12,11 +12,10 @@ defmodule Membrane.Core.InputBuffer do
   alias Membrane.Buffer
   alias Membrane.Core.Message
   alias Membrane.Pad
-  alias Membrane.Telemetry
-  alias Membrane.ComponentPath
 
   require Membrane.Core.Message
   require Membrane.Logger
+  require Membrane.Telemetry
 
   @qe Qex
 
@@ -326,17 +325,7 @@ defmodule Membrane.Core.InputBuffer do
   end
 
   defp report_buffer_size(method, size, %__MODULE__{log_tag: log_tag}) do
-    :telemetry.execute(
-      Telemetry.metric_event_name(),
-      %{
-        element_path:
-          ComponentPath.get_formatted() <>
-            "/" <> (log_tag || ""),
-        metric: method,
-        value: size
-      },
-      %{}
-    )
+    Membrane.Telemetry.report_metric(method, size, log_tag)
   end
 
   @spec empty?(t()) :: boolean()

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -327,12 +327,12 @@ defmodule Membrane.Core.InputBuffer do
 
   defp report_buffer_size(method, size, %__MODULE__{log_tag: log_tag}) do
     :telemetry.execute(
-      Telemetry.input_buffer_size_event_name(),
+      Telemetry.metric_event_name(),
       %{
         element_path:
           ComponentPath.get_formatted() <>
             "/" <> (log_tag || ""),
-        method: method,
+        metric: method,
         value: size
       },
       %{}

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -12,6 +12,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
 
   require Membrane.Core.Message
   require Membrane.Pad
+  require Membrane.Telemetry
 
   @spec resolve_links([LinkParser.raw_link_t()], Parent.state_t()) ::
           [Parent.Link.t()]
@@ -138,36 +139,12 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
     end
   end
 
-  defp get_public_pad_name(pad) do
-    case pad do
-      {:private, direction} -> direction
-      {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}
-      _pad -> pad
-    end
-  end
-
-  defp report_new_link(from, to) do
-    %Endpoint{child: from_child, pad_ref: from_pad} = from
-    %Endpoint{child: to_child, pad_ref: to_pad} = to
-
-    :telemetry.execute(
-      Membrane.Telemetry.new_link_event_name(),
-      %{
-        parent_path: Membrane.ComponentPath.get_formatted(),
-        from: "#{inspect(from_child)}",
-        to: "#{inspect(to_child)}",
-        pad_from: "#{inspect(get_public_pad_name(from_pad))}",
-        pad_to: "#{inspect(get_public_pad_name(to_pad))}"
-      }
-    )
-  end
-
   defp link(%Link{from: %Endpoint{child: child}, to: %Endpoint{child: child}}, _state) do
     raise LinkError, "Tried to link element #{inspect(child)} with itself"
   end
 
   defp link(%Link{from: from, to: to}, state) do
-    report_new_link(from, to)
+    Membrane.Telemetry.report_new_link(from, to)
     do_link(from, to, state)
   end
 

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -11,8 +11,8 @@ defmodule Membrane.Telemetry do
 
   The following events are published by Membrane's Core with following measurement types and metadata:
 
-    * `[:membrane, :input_buffer, :size]` - to report current input buffer's size.
-        * Measurement: `t:input_buffer_size_event_value_t/0`
+    * `[:membrane, :metric, :value]` - used by `Membrane.Core.InputBuffer` to report current buffer's size inside functions `Membrane.Core.InputBuffer.store/3` and `Membrane.Core.InputBuffer.take_and_demand/4`. TODO add info about rest of metrics
+        * Measurement: `t:metric_event_value_t/0`
         * Metadata: `%{}`
 
     * `[:membrane, :link, :new]` - to report new link connection being initialized in pipeline.
@@ -25,18 +25,18 @@ defmodule Membrane.Telemetry do
 
   @typedoc """
   * element_path - element's process path with pad's name that input buffer is attached to
-  * method - input buffer's function call name
-  * value - current buffer's size
+  * metric - metric name
+  * value - metric's value
 
   """
-  @type input_buffer_size_event_value_t :: %{
+  @type metric_event_value_t :: %{
           element_path: String.t(),
-          method: String.t(),
+          metric: String.t(),
           value: integer()
         }
 
-  @spec input_buffer_size_event_name() :: event_name_t()
-  def input_buffer_size_event_name, do: [:membrane, :input_buffer, :size]
+  @spec metric_event_name() :: event_name_t()
+  def metric_event_name, do: [:membrane, :metric, :value]
 
   @typedoc """
   * parent_path - process path of link's parent

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -11,7 +11,7 @@ defmodule Membrane.Telemetry do
 
   The following events are published by Membrane's Core with following measurement types and metadata:
 
-    * `[:membrane, :metric, :value]` - used by `Membrane.Core.InputBuffer` to report current buffer's size inside functions `Membrane.Core.InputBuffer.store/3` and `Membrane.Core.InputBuffer.take_and_demand/4`. TODO add info about rest of metrics
+    * `[:membrane, :metric, :value]` - used to report metrics, such as input buffer's size inside functions `Membrane.Core.InputBuffer.store/3` and `Membrane.Core.InputBuffer.take_and_demand/4`, incoming events in `Membrane.Core.Element.EventController` and received caps in `Membrane.Core.Element.CapsController`.
         * Measurement: `t:metric_event_value_t/0`
         * Metadata: `%{}`
 

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -32,7 +32,7 @@ defmodule Membrane.Telemetry do
 
   @typedoc """
   * element_path - element's process path with pad's name that input buffer is attached to
-  * metric - metric name
+  * metric - metric's name
   * value - metric's value
 
   """
@@ -41,9 +41,6 @@ defmodule Membrane.Telemetry do
           metric: String.t(),
           value: integer()
         }
-
-  @spec metric_event_name() :: event_name_t()
-  def metric_event_name, do: [:membrane, :metric, :value]
 
   @typedoc """
   * parent_path - process path of link's parent
@@ -60,9 +57,6 @@ defmodule Membrane.Telemetry do
           pad_to: String.t()
         }
 
-  @spec new_link_event_name() :: event_name_t()
-  def new_link_event_name, do: [:membrane, :link, :new]
-
   @doc """
   Macro for reporting metric measurements.
 
@@ -76,7 +70,7 @@ defmodule Membrane.Telemetry do
         path = ComponentPath.get_formatted() <> "/" <> (unquote(log_tag) || "")
 
         :telemetry.execute(
-          unquote(metric_event_name()),
+          [:membrane, :metric, :value],
           %{
             element_path: path,
             metric: unquote(metric),
@@ -124,7 +118,7 @@ defmodule Membrane.Telemetry do
         %Endpoint{child: to_child, pad_ref: to_pad} = unquote(to)
 
         :telemetry.execute(
-          unquote(new_link_event_name()),
+          [:membrane, :link, :new],
           %{
             parent_path: Membrane.ComponentPath.get_formatted(),
             from: "#{inspect(from_child)}",

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Telemetry do
   @moduledoc """
-  Defines basic telemetry event types used by Membrane's Core.
+  Defines basic telemetry event types used by Membrane's Core and reports them.
   Membrane uses [Telemetry Package](https://hex.pm/packages/telemetry) for instrumentation and does not store or save any measurements by itself.
 
   It is user's responsibility to use some sort of metrics reporter
@@ -11,7 +11,7 @@ defmodule Membrane.Telemetry do
 
   The following events are published by Membrane's Core with following measurement types and metadata:
 
-    * `[:membrane, :metric, :value]` - used to report metrics, such as input buffer's size inside functions `Membrane.Core.InputBuffer.store/3` and `Membrane.Core.InputBuffer.take_and_demand/4`, incoming events in `Membrane.Core.Element.EventController` and received caps in `Membrane.Core.Element.CapsController`.
+    * `[:membrane, :metric, :value]` - used to report metrics, such as input buffer's size inside functions, incoming events and received caps.
         * Measurement: `t:metric_event_value_t/0`
         * Metadata: `%{}`
 
@@ -19,7 +19,14 @@ defmodule Membrane.Telemetry do
         * Measurement: `t:new_link_event_value_t/0`
         * Metadata: `%{}`
 
+  It also privides macros to report metrics. Metrics are reported only when application using Membrane Core specifies following in compile-time config file:
+
+      config :membrane_core,
+        enable_metrics: true
+
   """
+
+  @enable_metrics Application.compile_env(:membrane_core, :enable_metrics, false)
 
   @type event_name_t :: [atom(), ...]
 
@@ -55,4 +62,88 @@ defmodule Membrane.Telemetry do
 
   @spec new_link_event_name() :: event_name_t()
   def new_link_event_name, do: [:membrane, :link, :new]
+
+  @doc """
+  Macro for reporting metric measurements.
+
+  Metrics are reported only when it is enabled in the application using Membrane Core.
+  """
+  defmacro report_metric(metric, value, log_tag) do
+    if @enable_metrics do
+      quote do
+        alias Membrane.ComponentPath
+
+        path = ComponentPath.get_formatted() <> "/" <> (unquote(log_tag) || "")
+
+        :telemetry.execute(
+          unquote(metric_event_name()),
+          %{
+            element_path: path,
+            metric: unquote(metric),
+            value: unquote(value)
+          },
+          %{}
+        )
+      end
+    else
+      # A hack to suppress the 'unused variable' warnings
+      quote do
+        fn ->
+          _unused = unquote(metric)
+          _unused = unquote(value)
+          _unused = unquote(log_tag)
+        end
+
+        :ok
+      end
+    end
+  end
+
+  @doc """
+  Macro for reporting new links.
+
+  Links are reported only when metrics reporting is enabled in the application using Membrane Core.
+  """
+  defmacro report_new_link(from, to) do
+    if @enable_metrics do
+      quote do
+        alias Membrane.ComponentPath
+        alias Membrane.Core.Parent.Link.Endpoint
+
+        require Membrane.Pad
+
+        get_public_pad_name = fn pad ->
+          case pad do
+            {:private, direction} -> direction
+            {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}
+            _pad -> pad
+          end
+        end
+
+        %Endpoint{child: from_child, pad_ref: from_pad} = unquote(from)
+        %Endpoint{child: to_child, pad_ref: to_pad} = unquote(to)
+
+        :telemetry.execute(
+          unquote(new_link_event_name()),
+          %{
+            parent_path: Membrane.ComponentPath.get_formatted(),
+            from: "#{inspect(from_child)}",
+            to: "#{inspect(to_child)}",
+            pad_from: "#{inspect(get_public_pad_name.(from_pad))}",
+            pad_to: "#{inspect(get_public_pad_name.(to_pad))}"
+          }
+        )
+      end
+    else
+      # A hack to suppress 'unused variable' warnings
+      quote do
+        fn ->
+          _unused = unquote(from)
+          _unused = unquote(to)
+        end
+
+        :ok
+      end
+    end
+  end
 end


### PR DESCRIPTION
Work in progress.

Current changes:
- `method` is now called `metric`
- `input_buffer_size_event` is now called `metric_event`
- added reporting `caps`
- added reporting `event`
- added possibility to disable reporting metrics

Adds two metrics from [Add more telemetry events #297](https://github.com/membraneframework/membrane_core/issues/297)