### PR TITLE
Added init/termiante telemetry events

### DIFF
--- a/lib/membrane/component_path.ex
+++ b/lib/membrane/component_path.ex
@@ -10,6 +10,24 @@ defmodule Membrane.ComponentPath do
   @key :membrane_path
 
   @doc """
+  Prepends a nonce string to given name and initializes the current path.
+
+  Nonce is used to guarantee path uniqueness between different application runs.
+  Prepended nonce is of format '([A-Za-z0-9+]) '.
+  """
+  @spec init_with_nonce(String.t()) :: :ok
+  def init_with_nonce(name) do
+    nonce =
+      :crypto.strong_rand_bytes(4)
+      |> Base.encode64()
+      |> String.trim_trailing("==")
+      |> String.replace("/", "O")
+
+    Process.put(@key, ["(#{nonce}) #{name}"])
+    :ok
+  end
+
+  @doc """
   Appends given name to the current path.
 
   If path has not been previously set then creates new one with given name.

--- a/lib/membrane/component_path.ex
+++ b/lib/membrane/component_path.ex
@@ -10,24 +10,6 @@ defmodule Membrane.ComponentPath do
   @key :membrane_path
 
   @doc """
-  Prepends a nonce string to given name and initializes the current path.
-
-  Nonce is used to guarantee path uniqueness between different application runs.
-  Prepended nonce is of format '([A-Za-z0-9+]) '.
-  """
-  @spec init_with_nonce(String.t()) :: :ok
-  def init_with_nonce(name) do
-    nonce =
-      :crypto.strong_rand_bytes(4)
-      |> Base.encode64()
-      |> String.trim_trailing("==")
-      |> String.replace("/", "O")
-
-    Process.put(@key, ["(#{nonce}) #{name}"])
-    :ok
-  end
-
-  @doc """
   Appends given name to the current path.
 
   If path has not been previously set then creates new one with given name.

--- a/lib/membrane/core/bin.ex
+++ b/lib/membrane/core/bin.ex
@@ -82,7 +82,7 @@ defmodule Membrane.Core.Bin do
     Logger.metadata(log_metadata)
     :ok = ComponentPath.set_and_append(log_metadata[:parent_path] || [], name_str <> " bin")
 
-    Telemetry.report_init(:bin, ComponentPath.get())
+    Telemetry.report_init(:bin)
 
     clock_proxy = Membrane.Clock.start_link(proxy: true) ~> ({:ok, pid} -> pid)
     clock = if Bunch.Module.check_behaviour(module, :membrane_clock?), do: clock_proxy, else: nil
@@ -174,7 +174,7 @@ defmodule Membrane.Core.Bin do
 
   @impl GenServer
   def terminate(reason, state) do
-    Telemetry.report_terminate(:bin, ComponentPath.get())
+    Telemetry.report_terminate(:bin)
 
     :ok = state.module.handle_shutdown(reason, state.internal_state)
   end

--- a/lib/membrane/core/bin.ex
+++ b/lib/membrane/core/bin.ex
@@ -11,6 +11,7 @@ defmodule Membrane.Core.Bin do
   alias Membrane.Core.Child.{PadController, PadSpecHandler}
 
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @type options_t :: %{

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -100,7 +100,7 @@ defmodule Membrane.Core.Element do
 
     :ok = ComponentPath.set_and_append(options.log_metadata[:parent_path] || [], name_str)
 
-    Telemetry.report_init(:element, ComponentPath.get())
+    Telemetry.report_init(:element)
 
     state =
       options
@@ -117,7 +117,7 @@ defmodule Membrane.Core.Element do
 
   @impl GenServer
   def terminate(reason, state) do
-    Telemetry.report_terminate(:element, ComponentPath.get())
+    Telemetry.report_terminate(:element)
 
     {:ok, _state} = LifecycleController.handle_shutdown(reason, state)
 

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -22,7 +22,7 @@ defmodule Membrane.Core.Element do
 
   alias Membrane.{Clock, Element, Sync}
   alias Membrane.Core.Element.{LifecycleController, PlaybackBuffer, State}
-  alias Membrane.Core.{Child, Message, PlaybackHandler, TimerController}
+  alias Membrane.Core.{Child, Message, PlaybackHandler, Telemetry, TimerController}
   alias Membrane.ComponentPath
   alias Membrane.Core.Child.PadController
 
@@ -100,6 +100,8 @@ defmodule Membrane.Core.Element do
 
     :ok = ComponentPath.set_and_append(options.log_metadata[:parent_path] || [], name_str)
 
+    Telemetry.report_init(:element, ComponentPath.get())
+
     state =
       options
       |> Map.take([:module, :name, :parent_clock, :sync])
@@ -115,6 +117,8 @@ defmodule Membrane.Core.Element do
 
   @impl GenServer
   def terminate(reason, state) do
+    Telemetry.report_terminate(:element, ComponentPath.get())
+
     {:ok, _state} = LifecycleController.handle_shutdown(reason, state)
 
     :ok

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -27,6 +27,7 @@ defmodule Membrane.Core.Element do
   alias Membrane.Core.Child.PadController
 
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @type options_t :: %{
@@ -212,6 +213,11 @@ defmodule Membrane.Core.Element do
 
   @impl GenServer
   def handle_info(message, state) do
+    Telemetry.report_metric(
+      :queue_len,
+      :erlang.process_info(self(), :message_queue_len) |> elem(1)
+    )
+
     LifecycleController.handle_other(message, state) |> noreply(state)
   end
 end

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -16,9 +16,10 @@ defmodule Membrane.Core.Element.ActionHandler do
   alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
   alias Membrane.Element.Action
 
-  require Membrane.Logger
   require Membrane.Core.Child.PadModel
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
+  require Membrane.Logger
 
   @impl CallbackHandler
   def handle_action(action, callback, params, state) do

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -12,6 +12,7 @@ defmodule Membrane.Core.Element.ActionHandler do
   alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
   alias Membrane.Core.{Events, Message, PlaybackHandler, TimerController}
   alias Membrane.Core.Child.PadModel
+  alias Membrane.Core.Telemetry
   alias Membrane.Core.Element.{DemandHandler, LifecycleController, State}
   alias Membrane.Element.Action
 
@@ -78,6 +79,12 @@ defmodule Membrane.Core.Element.ActionHandler do
 
   defp do_handle_action({:buffer, {pad_ref, buffers}}, cb, _params, %State{type: type} = state)
        when type in [:source, :filter] and is_pad_ref(pad_ref) do
+
+    # all this telemetry seems soo expensive..
+    Telemetry.report_metric(:buffer, if(is_list(buffers), do: length(buffers), else: 1))
+    Telemetry.report_metric(:bitrate, 8 * if(is_list(buffers), do: Enum.reduce(buffers, 0, &(byte_size(&1.payload) + &2)), else: byte_size(buffers.payload)))
+    Telemetry.report_metric(:queue_len, :erlang.process_info(self(), :message_queue_len) |> elem(1))
+
     send_buffer(pad_ref, buffers, cb, state)
   end
 

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -79,15 +79,6 @@ defmodule Membrane.Core.Element.ActionHandler do
 
   defp do_handle_action({:buffer, {pad_ref, buffers}}, cb, _params, %State{type: type} = state)
        when type in [:source, :filter] and is_pad_ref(pad_ref) do
-    Telemetry.report_metric(:buffer, if(is_list(buffers), do: length(buffers), else: 1))
-
-    Telemetry.report_metric(
-      :queue_len,
-      :erlang.process_info(self(), :message_queue_len) |> elem(1)
-    )
-
-    Telemetry.report_bitrate(buffers)
-
     send_buffer(pad_ref, buffers, cb, state)
   end
 
@@ -262,6 +253,9 @@ defmodule Membrane.Core.Element.ActionHandler do
     Membrane.Logger.debug_verbose(
       "Sending #{length(buffers)} buffer(s) through pad #{inspect(pad_ref)}"
     )
+
+    Telemetry.report_metric(:buffer, length(buffers))
+    Telemetry.report_bitrate(buffers)
 
     withl buffers:
             :ok <-

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -79,9 +79,13 @@ defmodule Membrane.Core.Element.ActionHandler do
 
   defp do_handle_action({:buffer, {pad_ref, buffers}}, cb, _params, %State{type: type} = state)
        when type in [:source, :filter] and is_pad_ref(pad_ref) do
-
     Telemetry.report_metric(:buffer, if(is_list(buffers), do: length(buffers), else: 1))
-    Telemetry.report_metric(:queue_len, :erlang.process_info(self(), :message_queue_len) |> elem(1))
+
+    Telemetry.report_metric(
+      :queue_len,
+      :erlang.process_info(self(), :message_queue_len) |> elem(1)
+    )
+
     Telemetry.report_bitrate(buffers)
 
     send_buffer(pad_ref, buffers, cb, state)

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -80,10 +80,9 @@ defmodule Membrane.Core.Element.ActionHandler do
   defp do_handle_action({:buffer, {pad_ref, buffers}}, cb, _params, %State{type: type} = state)
        when type in [:source, :filter] and is_pad_ref(pad_ref) do
 
-    # all this telemetry seems soo expensive..
     Telemetry.report_metric(:buffer, if(is_list(buffers), do: length(buffers), else: 1))
-    Telemetry.report_metric(:bitrate, 8 * if(is_list(buffers), do: Enum.reduce(buffers, 0, &(byte_size(&1.payload) + &2)), else: byte_size(buffers.payload)))
     Telemetry.report_metric(:queue_len, :erlang.process_info(self(), :message_queue_len) |> elem(1))
+    Telemetry.report_bitrate(buffers)
 
     send_buffer(pad_ref, buffers, cb, state)
   end

--- a/lib/membrane/core/element/buffer_controller.ex
+++ b/lib/membrane/core/element/buffer_controller.ex
@@ -13,6 +13,7 @@ defmodule Membrane.Core.Element.BufferController do
   alias Membrane.Element.CallbackContext
 
   require Membrane.Core.Child.PadModel
+  require Membrane.Core.Telemetry
 
   @doc """
   Handles incoming buffer: either stores it in InputBuffer, or executes element's

--- a/lib/membrane/core/element/buffer_controller.ex
+++ b/lib/membrane/core/element/buffer_controller.ex
@@ -9,6 +9,7 @@ defmodule Membrane.Core.Element.BufferController do
   alias Membrane.Core.{CallbackHandler, InputBuffer}
   alias Membrane.Core.Child.PadModel
   alias Membrane.Core.Element.{ActionHandler, DemandHandler, State}
+  alias Membrane.Core.Telemetry
   alias Membrane.Element.CallbackContext
 
   require Membrane.Core.Child.PadModel
@@ -53,6 +54,9 @@ defmodule Membrane.Core.Element.BufferController do
 
   def exec_buffer_handler(pad_ref, buffers, params, %State{type: :sink} = state) do
     require CallbackContext.Write
+
+    Telemetry.report_metric(:buffer, length(List.wrap(buffers)))
+    Telemetry.report_bitrate(buffers)
 
     CallbackHandler.exec_and_handle_callback(
       :handle_write_list,

--- a/lib/membrane/core/element/caps_controller.ex
+++ b/lib/membrane/core/element/caps_controller.ex
@@ -12,6 +12,7 @@ defmodule Membrane.Core.Element.CapsController do
   alias Membrane.Element.CallbackContext
 
   require Membrane.Core.Child.PadModel
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @doc """

--- a/lib/membrane/core/element/caps_controller.ex
+++ b/lib/membrane/core/element/caps_controller.ex
@@ -19,7 +19,7 @@ defmodule Membrane.Core.Element.CapsController do
   """
   @spec handle_caps(Pad.ref_t(), Caps.t(), State.t()) :: State.stateful_try_t()
   def handle_caps(pad_ref, caps, state) do
-    Telemetry.report_metric("caps", 1, inspect(pad_ref))
+    Telemetry.report_metric(:caps, 1, inspect(pad_ref))
 
     PadModel.assert_data!(state, pad_ref, %{direction: :input})
     data = PadModel.get_data!(state, pad_ref)

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -13,6 +13,7 @@ defmodule Membrane.Core.Element.EventController do
 
   require Membrane.Core.Child.PadModel
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @spec handle_start_of_stream(Pad.ref_t(), State.t()) :: State.stateful_try_t()

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -27,7 +27,7 @@ defmodule Membrane.Core.Element.EventController do
   """
   @spec handle_event(Pad.ref_t(), Event.t(), State.t()) :: State.stateful_try_t()
   def handle_event(pad_ref, event, state) do
-    Telemetry.report_metric("event", 1, inspect(pad_ref))
+    Telemetry.report_metric(:event, 1, inspect(pad_ref))
 
     pad_data = PadModel.get_data!(state, pad_ref)
 

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -14,6 +14,7 @@ defmodule Membrane.Core.InputBuffer do
   alias Membrane.Pad
 
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @qe Qex

--- a/lib/membrane/core/input_buffer.ex
+++ b/lib/membrane/core/input_buffer.ex
@@ -133,7 +133,8 @@ defmodule Membrane.Core.InputBuffer do
 
     %__MODULE__{current_size: size} = input_buf = do_store_buffers(input_buf, v)
 
-    report_buffer_size("store", size, input_buf)
+    Telemetry.report_metric(:store, size, input_buf.log_tag)
+
     input_buf
   end
 
@@ -198,7 +199,7 @@ defmodule Membrane.Core.InputBuffer do
         :ok
     end
 
-    report_buffer_size("store", size, input_buf)
+    Telemetry.report_metric(:store, size, input_buf.log_tag)
 
     input_buf
   end
@@ -209,7 +210,7 @@ defmodule Membrane.Core.InputBuffer do
       when type in @non_buf_types do
     "Storing #{type}" |> mk_log(input_buf) |> Membrane.Logger.debug_verbose()
 
-    report_buffer_size("store", size, input_buf)
+    Telemetry.report_metric(:store, size, input_buf.log_tag)
 
     %__MODULE__{input_buf | q: q |> @qe.push({:non_buffer, type, v})}
   end
@@ -236,7 +237,7 @@ defmodule Membrane.Core.InputBuffer do
       |> Bunch.Struct.update_in(:demand, &(&1 + size - new_size))
       |> send_demands(demand_pid, demand_pad)
 
-    report_buffer_size("take_and_demand", new_size, input_buf)
+    Telemetry.report_metric(:take_and_demand, new_size, input_buf.log_tag)
 
     {out, input_buf}
   end
@@ -321,10 +322,6 @@ defmodule Membrane.Core.InputBuffer do
         "preferred size: #{inspect(pref_size)}"
       end
     ]
-  end
-
-  defp report_buffer_size(method, size, %__MODULE__{log_tag: log_tag}) do
-    Telemetry.report_metric(method, size, log_tag)
   end
 
   @spec empty?(t()) :: boolean()

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -143,7 +143,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
   end
 
   defp link(%Link{from: from, to: to}, state) do
-    Telemetry.report_new_link(from, to)
+    Telemetry.report_link(from, to)
     do_link(from, to, state)
   end
 

--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -11,6 +11,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
   alias Membrane.Pad
 
   require Membrane.Core.Message
+  require Membrane.Core.Telemetry
   require Membrane.Pad
 
   @spec resolve_links([LinkParser.raw_link_t()], Parent.state_t()) ::

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -15,7 +15,7 @@ defmodule Membrane.Core.Pipeline do
   def init({module, pipeline_options}) do
     # TODO: verify if this is event a valid approach to the problem
     # - nonce to make sure that pipeline gets unique identifier between runs
-    nonce = :crypto.strong_rand_bytes(4) |> Base.encode64() |> String.trim_trailing("==")
+    nonce = :crypto.strong_rand_bytes(4) |> Base.encode64() |> String.trim_trailing("==") |> String.replace("/", "")
     pipeline_name = "pipeline@#{:erlang.pid_to_list(self())}"
     :ok = Membrane.ComponentPath.set(["(#{nonce}) " <> pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -20,7 +20,7 @@ defmodule Membrane.Core.Pipeline do
     :ok = Membrane.ComponentPath.set(["(#{nonce}) " <> pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)
 
-    Telemetry.report_init(:pipeline, ComponentPath.get())
+    Telemetry.report_init(:pipeline)
 
     {:ok, clock} = Clock.start_link(proxy: true)
 
@@ -52,7 +52,7 @@ defmodule Membrane.Core.Pipeline do
 
   @impl GenServer
   def terminate(reason, state) do
-    Telemetry.report_terminate(:pipeline, ComponentPath.get())
+    Telemetry.report_terminate(:pipeline)
 
     :ok = state.module.handle_shutdown(reason, state.internal_state)
   end

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -12,16 +12,8 @@ defmodule Membrane.Core.Pipeline do
 
   @impl GenServer
   def init({module, pipeline_options}) do
-    # TODO: verify if this is event a valid approach to the problem
-    # - nonce to make sure that pipeline gets unique identifier between runs
-    nonce =
-      :crypto.strong_rand_bytes(4)
-      |> Base.encode64()
-      |> String.trim_trailing("==")
-      |> String.replace("/", "")
-
     pipeline_name = "pipeline@#{:erlang.pid_to_list(self())}"
-    :ok = Membrane.ComponentPath.set(["(#{nonce}) " <> pipeline_name])
+    :ok = Membrane.ComponentPath.init_with_nonce(pipeline_name)
     :ok = Membrane.Logger.set_prefix(pipeline_name)
 
     Telemetry.report_init(:pipeline)

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -14,7 +14,12 @@ defmodule Membrane.Core.Pipeline do
   def init({module, pipeline_options}) do
     # TODO: verify if this is event a valid approach to the problem
     # - nonce to make sure that pipeline gets unique identifier between runs
-    nonce = :crypto.strong_rand_bytes(4) |> Base.encode64() |> String.trim_trailing("==") |> String.replace("/", "")
+    nonce =
+      :crypto.strong_rand_bytes(4)
+      |> Base.encode64()
+      |> String.trim_trailing("==")
+      |> String.replace("/", "")
+
     pipeline_name = "pipeline@#{:erlang.pid_to_list(self())}"
     :ok = Membrane.ComponentPath.set(["(#{nonce}) " <> pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -8,6 +8,7 @@ defmodule Membrane.Core.Pipeline do
   alias Membrane.Core.Parent.MessageDispatcher
   alias Membrane.Core.Telemetry
 
+  require Membrane.Core.Telemetry
   require Membrane.Logger
 
   @impl GenServer

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -13,7 +13,7 @@ defmodule Membrane.Core.Pipeline do
   @impl GenServer
   def init({module, pipeline_options}) do
     pipeline_name = "pipeline@#{:erlang.pid_to_list(self())}"
-    :ok = Membrane.ComponentPath.init_with_nonce(pipeline_name)
+    :ok = Membrane.ComponentPath.set([pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)
 
     Telemetry.report_init(:pipeline)

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -4,7 +4,6 @@ defmodule Membrane.Core.Pipeline do
 
   alias __MODULE__.{ActionHandler, State}
   alias Membrane.Clock
-  alias Membrane.ComponentPath
   alias Membrane.Core.CallbackHandler
   alias Membrane.Core.Parent.MessageDispatcher
   alias Membrane.Core.Telemetry

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -56,8 +56,9 @@ defmodule Membrane.Core.Telemetry do
     report_event(event, value)
   end
 
-  @spec get_public_pad_name(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
-  def get_public_pad_name(pad) do
+  @doc false
+  @spec __get_public_pad_name__(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
+  def __get_public_pad_name__(pad) do
     case pad do
       {:private, direction} -> direction
       {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}
@@ -81,8 +82,8 @@ defmodule Membrane.Core.Telemetry do
           from: inspect(unquote(from).child),
           to: inspect(unquote(to).child),
           pad_from:
-            Membrane.Core.Telemetry.get_public_pad_name(unquote(from).pad_ref) |> inspect(),
-          pad_to: Membrane.Core.Telemetry.get_public_pad_name(unquote(to).pad_ref) |> inspect()
+            Membrane.Core.Telemetry.__get_public_pad_name__(unquote(from).pad_ref) |> inspect(),
+          pad_to: Membrane.Core.Telemetry.__get_public_pad_name__(unquote(to).pad_ref) |> inspect()
         }
       end
 

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -83,7 +83,8 @@ defmodule Membrane.Core.Telemetry do
           to: inspect(unquote(to).child),
           pad_from:
             Membrane.Core.Telemetry.__get_public_pad_name__(unquote(from).pad_ref) |> inspect(),
-          pad_to: Membrane.Core.Telemetry.__get_public_pad_name__(unquote(to).pad_ref) |> inspect()
+          pad_to:
+            Membrane.Core.Telemetry.__get_public_pad_name__(unquote(to).pad_ref) |> inspect()
         }
       end
 

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -63,11 +63,12 @@ defmodule Membrane.Core.Telemetry do
         component_path: ComponentPath.get_formatted() <> "/",
         metric: "bitrate",
         value:
-          8 * if is_list(buffers) do
-            Enum.reduce(buffers, 0, &(Membrane.Payload.size(&1.payload) + &2))
-          else
-            Membrane.Payload.size(buffers.payload)
-          end
+          8 *
+            if is_list(buffers) do
+              Enum.reduce(buffers, 0, &(Membrane.Payload.size(&1.payload) + &2))
+            else
+              Membrane.Payload.size(buffers.payload)
+            end
       }
     )
   end

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -69,27 +69,27 @@ defmodule Membrane.Core.Telemetry do
     )
   end
 
-  @spec report_init(:pipeline | :bin | :element, ComponentPath.path_t()) :: :ok
-  def report_init(type, path) do
+  @spec report_init(:pipeline | :bin | :element) :: :ok
+  def report_init(type) do
     report_event(
       case type do
         :pipeline -> Telemetry.pipeline_init_event_name()
         :bin -> Telemetry.bin_init_event_name()
         :element -> Telemetry.element_init_event_name()
       end,
-      %{path: ComponentPath.format(path)}
+      %{path: ComponentPath.get_formatted()}
     )
   end
 
-  @spec report_terminate(:pipeline | :bin | :element, ComponentPath.path_t()) :: :ok
-  def report_terminate(type, path) do
+  @spec report_terminate(:pipeline | :bin | :element) :: :ok
+  def report_terminate(type) do
     report_event(
       case type do
         :pipeline -> Telemetry.pipeline_terminate_event_name()
         :bin -> Telemetry.bin_terminate_event_name()
         :element -> Telemetry.element_terminate_event_name()
       end,
-      %{path: ComponentPath.format(path)}
+      %{path: ComponentPath.get_formatted()}
     )
   end
 

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -2,18 +2,128 @@ defmodule Membrane.Core.Telemetry do
   @moduledoc false
 
   alias Membrane.ComponentPath
-  alias Membrane.Core.Parent.Link.Endpoint
 
   require Membrane.Pad
 
   @enable_telemetry Application.compile_env(:membrane_core, :enable_telemetry, false)
 
   @doc """
-  Macro for reporting metrics.
-
-  Metrics are reported only when it is enabled in the application using Membrane Core.
+  Reports metrics such as input buffer's size inside functions, incoming events and received caps.
   """
-  defmacro report_event(event_name, measurement) do
+  defmacro report_metric(metric, value, log_tag \\ nil) do
+    event =
+      quote do
+        [:membrane, :metric, :value]
+      end
+
+    value =
+      quote do
+        %{
+          component_path: ComponentPath.get_formatted() <> "/" <> (unquote(log_tag) || ""),
+          metric: Atom.to_string(unquote(metric)),
+          value: unquote(value)
+        }
+      end
+
+    report_event(event, value)
+  end
+
+  @doc """
+  Given list of buffers (or a single buffer) calculates total size of their payloads in bits
+  and reports it.
+  """
+  defmacro report_bitrate(buffers) do
+    event =
+      quote do
+        [:membrane, :metric, :value]
+      end
+
+    value =
+      quote do
+        %{
+          component_path: ComponentPath.get_formatted() <> "/",
+          metric: "bitrate",
+          value:
+            8 *
+              Enum.reduce(
+                List.wrap(unquote(buffers)),
+                0,
+                &(Membrane.Payload.size(&1.payload) + &2)
+              )
+        }
+      end
+
+    report_event(event, value)
+  end
+
+  def get_public_pad_name(pad) do
+    case pad do
+      {:private, direction} -> direction
+      {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}
+      _pad -> pad
+    end
+  end
+
+  @doc """
+  Reports new link connection being initialized in pipeline.
+  """
+  defmacro report_link(from, to) do
+    event =
+      quote do
+        [:membrane, :link, :new]
+      end
+
+    value =
+      quote do
+        %{
+          parent_path: Membrane.ComponentPath.get_formatted(),
+          from: inspect(unquote(from).child),
+          to: inspect(unquote(to).child),
+          pad_from:
+            Membrane.Core.Telemetry.get_public_pad_name(unquote(from).pad_ref) |> inspect(),
+          pad_to: Membrane.Core.Telemetry.get_public_pad_name(unquote(to).pad_ref) |> inspect()
+        }
+      end
+
+    report_event(event, value)
+  end
+
+  @doc """
+  Reports a pipeline/bin/element initialization.
+  """
+  defmacro report_init(type) when type in [:pipeline, :bin, :element] do
+    event =
+      quote do
+        [:membrane, unquote(type), :init]
+      end
+
+    value =
+      quote do
+        %{path: ComponentPath.get_formatted()}
+      end
+
+    report_event(event, value)
+  end
+
+  @doc """
+  Reports a pipeline/bin/element termination.
+  """
+  defmacro report_terminate(type) when type in [:pipeline, :bin, :element] do
+    event =
+      quote do
+        [:membrane, unquote(type), :terminate]
+      end
+
+    value =
+      quote do
+        %{path: ComponentPath.get_formatted()}
+      end
+
+    report_event(event, value)
+  end
+
+  # Conditional event reporting of telemetry events
+  defp report_event(event_name, measurement) do
     if @enable_telemetry do
       quote do
         :telemetry.execute(
@@ -32,84 +142,6 @@ defmodule Membrane.Core.Telemetry do
 
         :ok
       end
-    end
-  end
-
-  @doc """
-  Reports metrics such as input buffer's size inside functions, incoming events and received caps.
-  """
-  @compile {:inline, report_metric: 3}
-  @spec report_metric(atom(), integer(), String.t() | nil) :: :ok
-  def report_metric(metric, value, log_tag \\ nil) do
-    report_event(
-      [:membrane, :metric, :value],
-      %{
-        component_path: ComponentPath.get_formatted() <> "/" <> (log_tag || ""),
-        metric: Atom.to_string(metric),
-        value: value
-      }
-    )
-  end
-
-  @doc """
-  Given list of buffers (or a single buffer) calculates total size of their payloads in bits
-  and reports it.
-  """
-  @compile {:inline, report_bitrate: 1}
-  @spec report_bitrate(buffers :: [Membrane.Buffer.t()] | Membrane.Buffer.t()) :: :ok
-  def report_bitrate(buffers) do
-    report_event(
-      [:membrane, :metric, :value],
-      %{
-        component_path: ComponentPath.get_formatted() <> "/",
-        metric: "bitrate",
-        value: 8 * Enum.reduce(List.wrap(buffers), 0, &(Membrane.Payload.size(&1.payload) + &2))
-      }
-    )
-  end
-
-  @doc """
-  Reports new link connection being initialized in pipeline.
-  """
-  @compile {:inline, report_link: 2}
-  @spec report_link(Endpoint.t(), Endpoint.t()) :: :ok
-  def report_link(from, to) do
-    report_event(
-      [:membrane, :link, :new],
-      %{
-        parent_path: Membrane.ComponentPath.get_formatted(),
-        from: inspect(from.child),
-        to: inspect(to.child),
-        pad_from: get_public_pad_name(from.pad_ref) |> inspect(),
-        pad_to: get_public_pad_name(to.pad_ref) |> inspect()
-      }
-    )
-  end
-
-  @compile {:inline, report_init: 1}
-  @spec report_init(:pipeline | :bin | :element) :: :ok
-  def report_init(type) when type in [:pipeline, :bin, :element] do
-    report_event(
-      [:membrane, type, :init],
-      %{path: ComponentPath.get_formatted()}
-    )
-  end
-
-  @compile {:inline, report_terminate: 1}
-  @spec report_terminate(:pipeline | :bin | :element) :: :ok
-  def report_terminate(type) when type in [:pipeline, :bin, :element] do
-    report_event(
-      [:membrane, type, :terminate],
-      %{path: ComponentPath.get_formatted()}
-    )
-  end
-
-  @spec get_public_pad_name(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
-  def get_public_pad_name(pad) do
-    case pad do
-      {:private, direction} -> direction
-      {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}
-      _pad -> pad
     end
   end
 end

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -19,7 +19,6 @@ defmodule Membrane.Core.Telemetry do
       quote do
         :telemetry.execute(
           unquote(event_name),
-          # if(is_function(unquote(measurement)), do: unquote(measurement).(), else: unquote(measurement)),
           unquote(measurement),
           %{}
         )
@@ -48,6 +47,27 @@ defmodule Membrane.Core.Telemetry do
         component_path: ComponentPath.get_formatted() <> "/" <> (log_tag || ""),
         metric: Atom.to_string(metric),
         value: value
+      }
+    )
+  end
+
+  @doc """
+  Given list of buffers (or a single buffer) calculates total size of their payloads in bits
+  and reports it.
+  """
+  @spec report_bitrate([Membrane.Buffer.t()] | Membrane.Buffer.t()) :: :ok
+  def report_bitrate(buffers) do
+    report_event(
+      Telemetry.metric_event_name(),
+      %{
+        component_path: ComponentPath.get_formatted() <> "/",
+        metric: "bitrate",
+        value:
+          8 * if is_list(buffers) do
+            Enum.reduce(buffers, 0, &(Membrane.Payload.size(&1.payload) + &2))
+          else
+            Membrane.Payload.size(buffers.payload)
+          end
       }
     )
   end

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -55,7 +55,7 @@ defmodule Membrane.Core.Telemetry do
   Given list of buffers (or a single buffer) calculates total size of their payloads in bits
   and reports it.
   """
-  @spec report_bitrate([Membrane.Buffer.t()] | Membrane.Buffer.t()) :: :ok
+  @spec report_bitrate(buffers :: any()) :: :ok
   def report_bitrate(buffers) do
     report_event(
       Telemetry.metric_event_name(),
@@ -114,7 +114,8 @@ defmodule Membrane.Core.Telemetry do
     )
   end
 
-  defp get_public_pad_name(pad) do
+  @spec get_public_pad_name(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
+  def get_public_pad_name(pad) do
     case pad do
       {:private, direction} -> direction
       {Membrane.Pad, {:private, direction}, ref} -> {Membrane.Pad, direction, ref}

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -56,6 +56,7 @@ defmodule Membrane.Core.Telemetry do
     report_event(event, value)
   end
 
+  @spec get_public_pad_name(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
   def get_public_pad_name(pad) do
     case pad do
       {:private, direction} -> direction

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -40,13 +40,13 @@ defmodule Membrane.Core.Telemetry do
   @doc """
   Reports metrics such as input buffer's size inside functions, incoming events and received caps.
   """
-  @spec report_metric(String.t(), integer(), String.t()) :: :ok
-  def report_metric(metric, value, log_tag) do
+  @spec report_metric(atom(), integer(), String.t() | nil) :: :ok
+  def report_metric(metric, value, log_tag \\ nil) do
     report_event(
       Telemetry.metric_event_name(),
       %{
         component_path: ComponentPath.get_formatted() <> "/" <> (log_tag || ""),
-        metric: metric,
+        metric: Atom.to_string(metric),
         value: value
       }
     )

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -38,6 +38,7 @@ defmodule Membrane.Core.Telemetry do
   @doc """
   Reports metrics such as input buffer's size inside functions, incoming events and received caps.
   """
+  @compile {:inline, report_metric: 3}
   @spec report_metric(atom(), integer(), String.t() | nil) :: :ok
   def report_metric(metric, value, log_tag \\ nil) do
     report_event(
@@ -54,14 +55,15 @@ defmodule Membrane.Core.Telemetry do
   Given list of buffers (or a single buffer) calculates total size of their payloads in bits
   and reports it.
   """
-  @spec report_bitrate(buffers :: [Membrane.Buffer.t()]) :: :ok
+  @compile {:inline, report_bitrate: 1}
+  @spec report_bitrate(buffers :: [Membrane.Buffer.t()] | Membrane.Buffer.t()) :: :ok
   def report_bitrate(buffers) do
     report_event(
       [:membrane, :metric, :value],
       %{
         component_path: ComponentPath.get_formatted() <> "/",
         metric: "bitrate",
-        value: 8 * Enum.reduce(buffers, 0, &(Membrane.Payload.size(&1.payload) + &2))
+        value: 8 * Enum.reduce(List.wrap(buffers), 0, &(Membrane.Payload.size(&1.payload) + &2))
       }
     )
   end
@@ -69,6 +71,7 @@ defmodule Membrane.Core.Telemetry do
   @doc """
   Reports new link connection being initialized in pipeline.
   """
+  @compile {:inline, report_link: 2}
   @spec report_link(Endpoint.t(), Endpoint.t()) :: :ok
   def report_link(from, to) do
     report_event(
@@ -83,6 +86,7 @@ defmodule Membrane.Core.Telemetry do
     )
   end
 
+  @compile {:inline, report_init: 1}
   @spec report_init(:pipeline | :bin | :element) :: :ok
   def report_init(type) when type in [:pipeline, :bin, :element] do
     report_event(
@@ -91,6 +95,7 @@ defmodule Membrane.Core.Telemetry do
     )
   end
 
+  @compile {:inline, report_terminate: 1}
   @spec report_terminate(:pipeline | :bin | :element) :: :ok
   def report_terminate(type) when type in [:pipeline, :bin, :element] do
     report_event(

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -55,6 +55,7 @@ defmodule Membrane.Telemetry do
         }
 
   @spec metric_event_name() :: event_name_t()
+  @compile {:inline, metric_event_name: 0}
   def metric_event_name, do: [:membrane, :metric, :value]
 
   @typedoc """
@@ -73,14 +74,30 @@ defmodule Membrane.Telemetry do
         }
 
   @spec new_link_event_name() :: event_name_t()
+  @compile {:inline, new_link_event_name: 0}
   def new_link_event_name, do: [:membrane, :link, :new]
 
-  [:pipeline, :bin, :element]
-  |> Enum.each(fn type ->
-    @spec unquote(:"#{type}_init_event_name")() :: event_name_t()
-    def unquote(:"#{type}_init_event_name")(), do: [:membrane, unquote(type), :init]
+  @spec pipeline_init_event_name() :: event_name_t()
+  @compile {:inline, pipeline_init_event_name: 0}
+  def pipeline_init_event_name(), do: [:membrane, :pipeline, :init]
 
-    @spec unquote(:"#{type}_terminate_event_name")() :: event_name_t()
-    def unquote(:"#{type}_terminate_event_name")(), do: [:membrane, unquote(type), :terminate]
-  end)
+  @spec pipeline_terminate_event_name() :: event_name_t()
+  @compile {:inline, pipeline_terminate_event_name: 0}
+  def pipeline_terminate_event_name(), do: [:membrane, :pipeline, :terminate]
+
+  @spec bin_init_event_name() :: event_name_t()
+  @compile {:inline, bin_init_event_name: 0}
+  def bin_init_event_name(), do: [:membrane, :bin, :init]
+
+  @spec bin_terminate_event_name() :: event_name_t()
+  @compile {:inline, bin_terminate_event_name: 0}
+  def bin_terminate_event_name(), do: [:membrane, :_terminate, :terminate]
+
+  @spec element_init_event_name() :: event_name_t()
+  @compile {:inline, element_init_event_name: 0}
+  def element_init_event_name(), do: [:membrane, :element, :init]
+
+  @spec element_terminate_event_name() :: event_name_t()
+  @compile {:inline, element_terminate_event_name: 0}
+  def element_terminate_event_name(), do: [:membrane, :element, :terminate]
 end

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -54,10 +54,6 @@ defmodule Membrane.Telemetry do
           path: Membrane.ComponentPath.path_t()
         }
 
-  @spec metric_event_name() :: event_name_t()
-  @compile {:inline, metric_event_name: 0}
-  def metric_event_name, do: [:membrane, :metric, :value]
-
   @typedoc """
   * parent_path - process path of link's parent
   * from - from element name
@@ -72,32 +68,4 @@ defmodule Membrane.Telemetry do
           pad_from: String.t(),
           pad_to: String.t()
         }
-
-  @spec new_link_event_name() :: event_name_t()
-  @compile {:inline, new_link_event_name: 0}
-  def new_link_event_name, do: [:membrane, :link, :new]
-
-  @spec pipeline_init_event_name() :: event_name_t()
-  @compile {:inline, pipeline_init_event_name: 0}
-  def pipeline_init_event_name(), do: [:membrane, :pipeline, :init]
-
-  @spec pipeline_terminate_event_name() :: event_name_t()
-  @compile {:inline, pipeline_terminate_event_name: 0}
-  def pipeline_terminate_event_name(), do: [:membrane, :pipeline, :terminate]
-
-  @spec bin_init_event_name() :: event_name_t()
-  @compile {:inline, bin_init_event_name: 0}
-  def bin_init_event_name(), do: [:membrane, :bin, :init]
-
-  @spec bin_terminate_event_name() :: event_name_t()
-  @compile {:inline, bin_terminate_event_name: 0}
-  def bin_terminate_event_name(), do: [:membrane, :_terminate, :terminate]
-
-  @spec element_init_event_name() :: event_name_t()
-  @compile {:inline, element_init_event_name: 0}
-  def element_init_event_name(), do: [:membrane, :element, :init]
-
-  @spec element_terminate_event_name() :: event_name_t()
-  @compile {:inline, element_terminate_event_name: 0}
-  def element_terminate_event_name(), do: [:membrane, :element, :terminate]
 end

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -16,7 +16,15 @@ defmodule Membrane.Telemetry do
         * Metadata: `%{}`
 
     * `[:membrane, :link, :new]` - to report new link connection being initialized in pipeline.
-        * Measurement: `t:new_link_event_value_t/0`
+        * Measurement: `t:link_event_value_t/0`
+        * Metadata: `%{}`
+
+    * `[:membrane, :pipeline | :bin | :element, :init]` - to report pipeline/element/bin initialization
+        * Measurement: `t:init_or_terminate_event_value_t/0`
+        * Metadata: `%{}`
+
+    * `[:membrane, :pipeline | :bin | :element, :terminate]` - to report pipeline/element/bin termination
+        * Measurement: `t:init_or_terminate_event_value_t/0`
         * Metadata: `%{}`
 
   The measurements are reported only when application using Membrane Core specifies following in compile-time config file:
@@ -39,6 +47,13 @@ defmodule Membrane.Telemetry do
           value: integer()
         }
 
+  @typedoc """
+  * path - element's path
+  """
+  @type init_or_terminate_event_value_t :: %{
+          path: Membrane.ComponentPath.path_t()
+        }
+
   @spec metric_event_name() :: event_name_t()
   def metric_event_name, do: [:membrane, :metric, :value]
 
@@ -49,7 +64,7 @@ defmodule Membrane.Telemetry do
   * pad_from - from's pad name
   * pad_to - to's pad name
   """
-  @type new_link_event_value_t :: %{
+  @type link_event_value_t :: %{
           parent_path: String.t(),
           from: String.t(),
           to: String.t(),
@@ -59,4 +74,13 @@ defmodule Membrane.Telemetry do
 
   @spec new_link_event_name() :: event_name_t()
   def new_link_event_name, do: [:membrane, :link, :new]
+
+  [:pipeline, :bin, :element]
+  |> Enum.each(fn type ->
+    @spec unquote(:"#{type}_init_event_name")() :: event_name_t()
+    def unquote(:"#{type}_init_event_name")(), do: [:membrane, unquote(type), :init]
+
+    @spec unquote(:"#{type}_terminate_event_name")() :: event_name_t()
+    def unquote(:"#{type}_terminate_event_name")(), do: [:membrane, unquote(type), :terminate]
+  end)
 end


### PR DESCRIPTION
Besides reporting events mentioned in title also added `buffer`, `queue_len` and `bitrate` events, all of which are reported when the processing element sends buffers to its descendant.
