### PR TITLE
Allow to specify node when spawning bin or element.

### DIFF
--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -47,27 +47,41 @@ defmodule Membrane.Core.Element do
   """
   @spec start_link(options_t, GenServer.options()) :: GenServer.on_start()
   def start_link(options, process_options \\ []),
-    do: do_start(:start_link, options, process_options)
+    do: start_link(node(), options, process_options)
+
+  @spec start_link(node(), options_t, GenServer.options()) :: GenServer.on_start()
+  def start_link(node, options, process_options) when is_atom(node),
+    do: do_start(node, :start_link, options, process_options)
 
   @doc """
   Works similarly to `start_link/5`, but does not link to the current process.
   """
   @spec start(options_t, GenServer.options()) :: GenServer.on_start()
   def start(options, process_options \\ []),
-    do: do_start(:start, options, process_options)
+    do: start(node(), options, process_options)
 
-  defp do_start(method, options, process_options) do
+  @spec start(node(), options_t, GenServer.options()) :: GenServer.on_start()
+  def start(node, options, process_options),
+    do: do_start(node, :start, options, process_options)
+
+  defp do_start(node, method, options, process_options) do
     %{module: module, name: name, user_options: user_options} = options
 
     if Element.element?(options.module) do
       Membrane.Logger.debug("""
       Element #{method}: #{inspect(name)}
+      node: #{node},
       module: #{inspect(module)},
       element options: #{inspect(user_options)},
       process options: #{inspect(process_options)}
       """)
 
-      apply(GenServer, method, [__MODULE__, options, process_options])
+      # rpc if necessary
+      if node == node() do
+        apply(GenServer, method, [__MODULE__, options, process_options])
+      else
+        :rpc.call(node, GenServer, method, [__MODULE__, options, process_options])
+      end
     else
       raise """
       Cannot start element, passed module #{inspect(module)} is not a Membrane Element.

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -219,7 +219,13 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     Enum.each(
       members_pids,
       fn pid ->
-        if Process.alive?(pid), do: GenServer.stop(pid, {:shutdown, :membrane_crash_group_kill})
+        if node(pid) == node() do
+          if Process.alive?(pid),
+            do: GenServer.stop(pid, {:shutdown, :membrane_crash_group_kill})
+        else
+          if :rpc.call(node(pid), Process, :alive?, [pid]),
+            do: GenServer.stop(pid, {:shutdown, :membrane_crash_group_kill})
+        end
       end
     )
 

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -35,9 +35,13 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     :ok = StartupHandler.check_if_children_names_unique(children, state)
     syncs = StartupHandler.setup_syncs(children, spec.stream_sync)
 
+    # ensure node is set to local if it's nil in spec
+    node = spec.node || node()
+
     children =
       StartupHandler.start_children(
         children,
+        node,
         state.synchronization.clock_proxy,
         syncs,
         state.children_log_metadata

--- a/lib/membrane/parent_spec.ex
+++ b/lib/membrane/parent_spec.ex
@@ -236,9 +236,10 @@ defmodule Membrane.ParentSpec do
   @type t :: %__MODULE__{
           children: children_spec_t,
           links: links_spec_t,
-          crash_group: crash_group_spec_t(),
+          crash_group: crash_group_spec_t() | nil,
           stream_sync: :sinks | [[Child.name_t()]],
-          clock_provider: Child.name_t()
+          clock_provider: Child.name_t() | nil,
+          node: node() | nil
         }
 
   @valid_pad_prop_keys [:options, :buffer]
@@ -247,7 +248,8 @@ defmodule Membrane.ParentSpec do
             links: [],
             crash_group: nil,
             stream_sync: [],
-            clock_provider: nil
+            clock_provider: nil,
+            node: nil
 
   @doc """
   Begins a link.


### PR DESCRIPTION
Adds the ability to distribute elements across a cluster. It will use node in `%ParentSpec{}` in `ChildLifeController`.