### PR TITLE
Update telemetry dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.8.0
 ### Release notes:
+  * update telemetry dependency to also allow 1.0 #343
 
 ### PR's not influencing public API:
   * add CHANGELOG update verification #340

--- a/mix.exs
+++ b/mix.exs
@@ -112,7 +112,7 @@ defmodule Membrane.Mixfile do
       {:espec, "~> 1.8.3", only: :test},
       {:excoveralls, "~> 0.11", only: :test},
       {:qex, "~> 0.3"},
-      {:telemetry, "~> 0.4"},
+      {:telemetry, "~> 0.4 or ~> 1.0"},
       {:bunch, "~> 1.3"},
       {:ratio, "~> 2.0"}
     ]


### PR DESCRIPTION
This updates the telemetry dependency to use either 0.4 or 1.0. 

According to the [changelog](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100) there are no changes in 1.0.0, it is just to mark API stability.
