### PR TITLE
Preventing internal testing notifications from reaching pipeline module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+ ## 0.9.0
+ ### PRs not influencing public API:
+ * Prevent internal testing notifications from reaching pipeline module [#350](https://github.com/membraneframework/membrane_core/pull/350) 
+
 ## 0.8.1
  * allow telemetry in version 1.0 only [#347](https://github.com/membraneframework/membrane_core/pull/347)
-### PR's not influencing public API:
+### PRs not influencing public API:
  * fix action enforcing CHANGELOG update with PR [#345](https://github.com/membraneframework/membrane_core/pull/345)
  * Release membrane_core v0.8.1 [#348](https://github.com/membraneframework/membrane_core/pull/348)
 
@@ -8,7 +12,7 @@
 ### Release notes:
   * PTS and DTS timestamps were added to `Membrane.Buffer` structure explicitly. Timestamps should no longer live in `Membrane.Buffer.metadata` field [#335](https://github.com/membraneframework/membrane_core/pull/335).
 
-### PR's not influencing public API:
+### PRs not influencing public API:
   * add CHANGELOG update verification #340
   * action enforcing changelog fix #342
   * bump version to 0.8.0 #344

--- a/lib/membrane/testing/notification.ex
+++ b/lib/membrane/testing/notification.ex
@@ -1,0 +1,7 @@
+defmodule Membrane.Testing.Notification do
+  @moduledoc false
+
+  # Notification sent internally by `Membrane.Testing.Pipeline`
+  @enforce_keys [:payload]
+  defstruct @enforce_keys
+end

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -99,6 +99,7 @@ defmodule Membrane.Testing.Pipeline do
 
   alias Membrane.{Element, Pipeline}
   alias Membrane.ParentSpec
+  alias Membrane.Testing.Notification
 
   defmodule Options do
     @moduledoc """
@@ -298,6 +299,16 @@ defmodule Membrane.Testing.Pipeline do
       fn -> notify_playback_state_changed(:prepared, :stopped, state) end,
       state
     )
+  end
+
+  @impl true
+  def handle_notification(
+        %Notification{payload: notification},
+        from,
+        _ctx,
+        %State{} = state
+      ) do
+    notify_test_process({:handle_notification, {notification, from}}, state)
   end
 
   @impl true

--- a/lib/membrane/testing/sink.ex
+++ b/lib/membrane/testing/sink.ex
@@ -43,10 +43,8 @@ defmodule Membrane.Testing.Sink do
                 """
               ]
 
-  defmacrop notify(payload) do
-    quote do
-      [notify: %Notification{payload: unquote(payload)}]
-    end
+  defp notify(payload) do
+    [notify: %Notification{payload: payload}]
   end
 
   @impl true

--- a/lib/membrane/testing/sink.ex
+++ b/lib/membrane/testing/sink.ex
@@ -43,10 +43,6 @@ defmodule Membrane.Testing.Sink do
                 """
               ]
 
-  defp notify(payload) do
-    [notify: %Notification{payload: payload}]
-  end
-
   @impl true
   def handle_init(opts) do
     {:ok, opts}
@@ -86,5 +82,9 @@ defmodule Membrane.Testing.Sink do
       %{autodemand: false} -> {{:ok, notify({:buffer, buf})}, state}
       %{autodemand: true} -> {{:ok, [demand: :input] ++ notify({:buffer, buf})}, state}
     end
+  end
+
+  defp notify(payload) do
+    [notify: %Notification{payload: payload}]
   end
 end

--- a/lib/membrane/testing/sink.ex
+++ b/lib/membrane/testing/sink.ex
@@ -28,6 +28,8 @@ defmodule Membrane.Testing.Sink do
 
   use Membrane.Sink
 
+  alias Membrane.Testing.Notification
+
   def_input_pad :input,
     demand_unit: :buffers,
     caps: :any
@@ -40,6 +42,12 @@ defmodule Membrane.Testing.Sink do
                 If it is set to false demand has to be triggered manually by sending `:make_demand` message.
                 """
               ]
+
+  defmacrop notify(payload) do
+    quote do
+      [notify: %Notification{payload: unquote(payload)}]
+    end
+  end
 
   @impl true
   def handle_init(opts) do
@@ -54,20 +62,20 @@ defmodule Membrane.Testing.Sink do
 
   @impl true
   def handle_event(:input, event, _context, state) do
-    {{:ok, notify: {:event, event}}, state}
+    {{:ok, notify({:event, event})}, state}
   end
 
   @impl true
   def handle_start_of_stream(pad, _ctx, state),
-    do: {{:ok, notify: {:start_of_stream, pad}}, state}
+    do: {{:ok, notify({:start_of_stream, pad})}, state}
 
   @impl true
   def handle_end_of_stream(pad, _ctx, state),
-    do: {{:ok, notify: {:end_of_stream, pad}}, state}
+    do: {{:ok, notify({:end_of_stream, pad})}, state}
 
   @impl true
   def handle_caps(pad, caps, _context, state),
-    do: {{:ok, notify: {:caps, pad, caps}}, state}
+    do: {{:ok, notify({:caps, pad, caps})}, state}
 
   @impl true
   def handle_other({:make_demand, size}, _ctx, %{autodemand: false} = state) do
@@ -77,8 +85,8 @@ defmodule Membrane.Testing.Sink do
   @impl true
   def handle_write(:input, buf, _ctx, state) do
     case state do
-      %{autodemand: false} -> {{:ok, notify: {:buffer, buf}}, state}
-      %{autodemand: true} -> {{:ok, demand: :input, notify: {:buffer, buf}}, state}
+      %{autodemand: false} -> {{:ok, notify({:buffer, buf})}, state}
+      %{autodemand: true} -> {{:ok, [demand: :input] ++ notify({:buffer, buf})}, state}
     end
   end
 end

--- a/test/membrane/testing/sink_test.exs
+++ b/test/membrane/testing/sink_test.exs
@@ -2,6 +2,7 @@ defmodule Membrane.Testing.SinkTest do
   use ExUnit.Case
 
   alias Membrane.Testing.Sink
+  alias Membrane.Testing.Notification
 
   describe "Handle write" do
     test "demands when autodemand is true" do
@@ -10,7 +11,10 @@ defmodule Membrane.Testing.SinkTest do
       assert {{:ok, actions}, _state} =
                Sink.handle_write(:input, buffer, nil, %{autodemand: true})
 
-      assert actions == [demand: :input, notify: {:buffer, buffer}]
+      assert actions == [
+               demand: :input,
+               notify: %Notification{payload: {:buffer, buffer}}
+             ]
     end
 
     test "does not demand when autodemand is false" do
@@ -19,7 +23,7 @@ defmodule Membrane.Testing.SinkTest do
       assert {{:ok, actions}, _state} =
                Sink.handle_write(:input, buffer, nil, %{autodemand: false})
 
-      assert actions == [notify: {:buffer, buffer}]
+      assert actions == [notify: %Notification{payload: {:buffer, buffer}}]
     end
   end
 end


### PR DESCRIPTION
Changes from this Pull Request will make sure that notifications sent internally by different elements of Membrane.Testing will not be reaching the pipeline specified with `module` option

All notifications sent by Testing elements to Testing.Pipeline are now wrapped in `Membrane.Testing.Notification` struct. Previous implementation made it impossible to easily differentiate between user-specified notifications and those used by Testing module and introduced risk of conflicts