### PR TITLE
add no-changelog label check

### DIFF
--- a/.github/workflows/enforce-changelog-update.yml
+++ b/.github/workflows/enforce-changelog-update.yml
@@ -9,6 +9,7 @@ on:
         required: true   
 jobs:
   check-changelog-update:
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'no-changelog') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -31,4 +32,4 @@ jobs:
         uses: actions/github-script@v3
         with:
           script: |
-            core.setFailed('CHANGELOG has to be updated on pull request to master')
+            core.setFailed('Add label "no-changelog" or update CHANGELOG.md on pull request to master.')


### PR DESCRIPTION
Added the check that disables the action if PR has `no-changelog` label. The problem is when someone forgets to set this label, and the check fails and the label is added after that. For some reason rerunning the job doesn't help and one needs to trigger the workflow by pushing empty commit:
```
git commit --amend --no-edit
git push
```