### PR TITLE
remove secrets with GITHUB_TOKEN field

### DIFF
--- a/.github/workflows/enforce-changelog-update.yml
+++ b/.github/workflows/enforce-changelog-update.yml
@@ -3,10 +3,7 @@ on:
   pull_request:
     branches:
       - master
-  workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true   
+  workflow_call: 
 jobs:
   check-changelog-update:
     if: ${{ !contains( github.event.pull_request.labels.*.name, 'no-changelog') }}


### PR DESCRIPTION
For some reason, action with that field started to throw an error:
![image](https://user-images.githubusercontent.com/27630111/146754859-7790d069-9de8-4f3d-9de1-509813acbb07.png)

