### PR TITLE
Update CHANGELOG.md after sneaky release of v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
  ## 0.9.0
  * Fixed PadAdded spec [#359](https://github.com/membraneframework/membrane_core/pull/359)
  * More fine-grained control over emitted metrics [#365](https://github.com/membraneframework/membrane_core/pull/365)
- ### PRs not influencing public API:
+
+## 0.8.2
  * Prevent internal testing notifications from reaching pipeline module [#350](https://github.com/membraneframework/membrane_core/pull/350)
  * Fix unknown node error on distribution changes [#352](https://github.com/membraneframework/membrane_core/pull/352)
 


### PR DESCRIPTION
To release Membrane RTC Engine in v0.1.0 we needed to release bugfix related to distribution.
Therefore we created v0.8.2 which includes two PR inteded to be released in v0.9.0.

This PR updates CHANGELOG.md after sneaky v0.8.2 release.

v0.8.2 is on a separate branch `v0.8.2`