### PR TITLE
Added log metadata when reporting init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
  ## 0.9.0
  * More fine-grained control over emitted metrics [#365](https://github.com/membraneframework/membrane_core/pull/365)
- * Added log metadata when reporting init/terminate in telemetry [#376](https://github.com/membraneframework/membrane_core/pull/376)
+ * Added log metadata when reporting init in telemetry [#376](https://github.com/membraneframework/membrane_core/pull/376)
 
 ## 0.8.2
  * Fixed PadAdded spec [#359](https://github.com/membraneframework/membrane_core/pull/359)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
  ## 0.9.0
  * More fine-grained control over emitted metrics [#365](https://github.com/membraneframework/membrane_core/pull/365)
+ * Added log metadata when reporting init/terminate in telemetry [#376](https://github.com/membraneframework/membrane_core/pull/376)
 
 ## 0.8.2
  * Fixed PadAdded spec [#359](https://github.com/membraneframework/membrane_core/pull/359)

--- a/lib/membrane/core/bin.ex
+++ b/lib/membrane/core/bin.ex
@@ -81,12 +81,13 @@ defmodule Membrane.Core.Bin do
 
   @impl GenServer
   def init(options) do
-    Process.monitor(options.parent)
+    %{parent: parent, name: name, module: module, log_metadata: log_metadata} = options
 
-    %{name: name, module: module, log_metadata: log_metadata} = options
+    Process.monitor(parent)
+
     name_str = if String.valid?(name), do: name, else: inspect(name)
     :ok = Membrane.Logger.set_prefix(name_str <> " bin")
-    Logger.metadata(log_metadata)
+    :ok = Logger.metadata(log_metadata)
     :ok = ComponentPath.set_and_append(log_metadata[:parent_path] || [], name_str <> " bin")
 
     Telemetry.report_init(:bin)

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -100,11 +100,13 @@ defmodule Membrane.Core.Element do
 
   @impl GenServer
   def init(options) do
-    Process.monitor(options.parent)
-    name_str = if String.valid?(options.name), do: options.name, else: inspect(options.name)
+    %{parent: parent, name: name, log_metadata: log_metadata} = options
+
+    Process.monitor(parent)
+    name_str = if String.valid?(name), do: name, else: inspect(name)
     :ok = Membrane.Logger.set_prefix(name_str)
-    :ok = Logger.metadata(options.log_metadata)
-    :ok = ComponentPath.set_and_append(options.log_metadata[:parent_path] || [], name_str)
+    :ok = Logger.metadata(log_metadata)
+    :ok = ComponentPath.set_and_append(log_metadata[:parent_path] || [], name_str)
 
     Telemetry.report_init(:element)
 

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -17,6 +17,13 @@ defmodule Membrane.Core.Pipeline do
     :ok = Membrane.ComponentPath.set([pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)
 
+    # NOTE: this would be super helpful to get the metadata inside the `report_init`
+    # but it is not super intuitive for membrane users that this happens automatically on an arbitrary pipeline option...
+    :ok =
+      pipeline_options
+      |> Keyword.get(:log_metadata, [])
+      |> Logger.metadata()
+
     Telemetry.report_init(:pipeline)
 
     {:ok, clock} = Clock.start_link(proxy: true)

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -17,13 +17,6 @@ defmodule Membrane.Core.Pipeline do
     :ok = Membrane.ComponentPath.set([pipeline_name])
     :ok = Membrane.Logger.set_prefix(pipeline_name)
 
-    # NOTE: this would be super helpful to get the metadata inside the `report_init`
-    # but it is not super intuitive for membrane users that this happens automatically on an arbitrary pipeline option...
-    :ok =
-      pipeline_options
-      |> Keyword.get(:log_metadata, [])
-      |> Logger.metadata()
-
     Telemetry.report_init(:pipeline)
 
     {:ok, clock} = Clock.start_link(proxy: true)

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -140,16 +140,10 @@ defmodule Membrane.Core.Telemetry do
         %{path: ComponentPath.get_formatted()}
       end
 
-    metadata =
-      quote do
-        %{log_metadata: Logger.metadata()}
-      end
-
     report_event(
       event,
       value,
-      Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil,
-      metadata
+      Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil
     )
   end
 

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -113,7 +113,17 @@ defmodule Membrane.Core.Telemetry do
         %{path: ComponentPath.get_formatted()}
       end
 
-    report_event(event, value, Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil)
+    metadata =
+      quote do
+        %{log_metadata: Logger.metadata()}
+      end
+
+    report_event(
+      event,
+      value,
+      Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil,
+      metadata
+    )
   end
 
   @doc """
@@ -130,17 +140,27 @@ defmodule Membrane.Core.Telemetry do
         %{path: ComponentPath.get_formatted()}
       end
 
-    report_event(event, value, Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil)
+    metadata =
+      quote do
+        %{log_metadata: Logger.metadata()}
+      end
+
+    report_event(
+      event,
+      value,
+      Enum.find(@telemetry_flags, &(&1 == :inits_and_terminates)) != nil,
+      metadata
+    )
   end
 
   # Conditional event reporting of telemetry events
-  defp report_event(event_name, measurement, enable) do
+  defp report_event(event_name, measurement, enable, metadata \\ nil) do
     if enable do
       quote do
         :telemetry.execute(
           unquote(event_name),
           unquote(measurement),
-          %{}
+          unquote(metadata) || %{}
         )
       end
     else
@@ -149,6 +169,7 @@ defmodule Membrane.Core.Telemetry do
         fn ->
           _unused = unquote(event_name)
           _unused = unquote(measurement)
+          _unused = unquote(metadata)
         end
 
         :ok

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -20,11 +20,11 @@ defmodule Membrane.Telemetry do
 
     * `[:membrane, :pipeline | :bin | :element, :init]` - to report pipeline/element/bin initialization
         * Measurement: `t:init_or_terminate_event_value_t/0`
-        * Metadata: `%{}`
+        * Metadata: `%{log_metadata: keyword()}`, includes Logger's metadata of created component
 
     * `[:membrane, :pipeline | :bin | :element, :terminate]` - to report pipeline/element/bin termination
         * Measurement: `t:init_or_terminate_event_value_t/0`
-        * Metadata: `%{}`
+        * Metadata: `%{log_metadata: keyword()}`, includes Logger's metadata of terminated component
 
 
   ## Enabling certain metrics/events

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -24,7 +24,7 @@ defmodule Membrane.Telemetry do
 
     * `[:membrane, :pipeline | :bin | :element, :terminate]` - to report pipeline/element/bin termination
         * Measurement: `t:init_or_terminate_event_value_t/0`
-        * Metadata: `%{log_metadata: keyword()}`, includes Logger's metadata of terminated component
+        * Metadata: `%{}`
 
 
   ## Enabling certain metrics/events


### PR DESCRIPTION
The purpose of this PR is to add logger's metadata when reporting events such as `init/terminate` so that the element being created/terminated can be more easily distinguished beside having the already existing component's path, or so that it will carry arbitrary information necessary helpful for further processing. 