### PR TITLE
Bypass invalid table generation in pad docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
  ## 0.9.0
  * More fine-grained control over emitted metrics [#365](https://github.com/membraneframework/membrane_core/pull/365)
  * Added log metadata when reporting init in telemetry [#376](https://github.com/membraneframework/membrane_core/pull/376)
+ * Fix generation of pad documentation inside an element [#377](https://github.com/membraneframework/membrane_core/pull/377)
 
 ## 0.8.2
  * Fixed PadAdded spec [#359](https://github.com/membraneframework/membrane_core/pull/359)

--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -227,7 +227,7 @@ defmodule Membrane.Core.Child.PadsSpecs do
         }
       end)
       |> Enum.map_join("\n", fn {k, v} ->
-        "#{k} | #{v}"
+        "<tr><td>#{k}</td> <td>#{v}</td></tr>"
       end)
 
     options_doc =
@@ -247,7 +247,9 @@ defmodule Membrane.Core.Child.PadsSpecs do
       """
       ### `#{inspect(unquote(name))}`
 
+      <table>
       #{unquote(config_doc)}
+      </table>
       """ <> unquote(options_doc)
     end
   end
@@ -258,22 +260,22 @@ defmodule Membrane.Core.Child.PadsSpecs do
     |> Enum.map(fn
       {module, params} ->
         params_doc =
-          Enum.map_join(params, ",<br />", fn {k, v} ->
-            Bunch.Markdown.hard_indent("`#{k}: #{inspect(v)}`")
+          Enum.map_join(params, ",<br/>", fn {k, v} ->
+            Bunch.Markdown.hard_indent("<code>#{k}: #{inspect(v)}</code>")
           end)
 
-        "`#{inspect(module)}`, restrictions:<br />#{params_doc}"
+        "<code>#{inspect(module)}</code>, restrictions:<br/>#{params_doc}"
 
       module ->
-        "`#{inspect(module)}`"
+        "<code>#{inspect(module)}</code>"
     end)
     ~> (
       [doc] -> doc
-      docs -> docs |> Enum.join(",<br />")
+      docs -> docs |> Enum.join(",<br/>")
     )
   end
 
   defp generate_pad_property_doc(_k, v) do
-    "`#{inspect(v)}`"
+    "<code>#{inspect(v)}</code>"
   end
 end


### PR DESCRIPTION
Since `ex_doc` currently doesn't handle HTML inside a table, we can work around that problem by generating HTML for the table manually

Closes #356 