### PR TITLE
Update value returned by handle_init/1 in Membrane.Element.Base

### DIFF
--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -90,9 +90,7 @@ defmodule Membrane.Element.Base do
   and initialize element internal state. Internally it is invoked inside
   `c:GenServer.init/1` callback.
   """
-  @callback handle_init(options :: Element.options_t()) ::
-              {:ok, Element.state_t()}
-              | {:error, any}
+  @callback handle_init(options :: Element.options_t()) :: callback_return_t
 
   @doc """
   Callback invoked when element goes to `:prepared` state from state `:stopped` and should get


### PR DESCRIPTION
Old value returned by callback caused unnecessary Dialyzer warnings