### PR TITLE
add try-catch to the Message.call/5 implementation

### DIFF
--- a/lib/membrane/core/bin/pad_controller.ex
+++ b/lib/membrane/core/bin/pad_controller.ex
@@ -178,7 +178,7 @@ defmodule Membrane.Core.Bin.PadController do
     end
 
     reply =
-      Message.call(child_endpoint.pid, :handle_link, [
+      Message.call!(child_endpoint.pid, :handle_link, [
         direction,
         child_endpoint,
         other_endpoint,

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -40,6 +40,11 @@ defmodule Membrane.Core.Message do
     end
   end
 
+  @spec call!(GenServer.server(), type_t, args_t, opts_t, timeout()) :: term()
+  def call!(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
+    GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
+  end
+
   @spec for_pad(t()) :: Pad.ref_t()
   def for_pad(message(opts: opts)), do: Keyword.get(opts, :for_pad)
 

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -36,7 +36,7 @@ defmodule Membrane.Core.Message do
       GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
     catch
       :exit, reason ->
-        {:error, reason}
+        {:error, {:call_failure, reason}}
     end
   end
 

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -32,7 +32,12 @@ defmodule Membrane.Core.Message do
 
   @spec call(GenServer.server(), type_t, args_t, opts_t, timeout()) :: term()
   def call(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
-    GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
+    try do
+      GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
+    catch
+      :exit, reason ->
+        {:error, reason}
+    end
   end
 
   @spec for_pad(t()) :: Pad.ref_t()

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -30,7 +30,8 @@ defmodule Membrane.Core.Message do
     __MODULE__.send(self(), type, args, opts)
   end
 
-  @spec call(GenServer.server(), type_t, args_t, opts_t, timeout()) :: term()
+  @spec call(GenServer.server(), type_t, args_t, opts_t, timeout()) ::
+          term() | {:error, {:call_failure, any}}
   def call(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
     try do
       GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)

--- a/test/membrane/core/message_test.exs
+++ b/test/membrane/core/message_test.exs
@@ -24,8 +24,12 @@ defmodule Membrane.Core.MessageTest do
   end
 
   test "receiver process not alive" do
-    response = Message.call(:c.pid(0, 255, 0), :request, [], [], 500)
+    pid = spawn(fn -> 5 end)
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
 
-    assert match?({:error, _reason}, response)
+    response = Message.call(pid, :request, [], [], 500)
+
+    assert match?({:error, {:call_failure, _}}, response)
   end
 end

--- a/test/membrane/core/message_test.exs
+++ b/test/membrane/core/message_test.exs
@@ -25,7 +25,7 @@ defmodule Membrane.Core.MessageTest do
 
     test "return error when receiver process is not alive" do
       Process.flag(:trap_exit, true)
-      pid = spawn(fn -> 5 end)
+      pid = spawn_link(fn -> :ok end)
       assert_receive {:EXIT, ^pid, :normal}
 
       response = Message.call(pid, :request, [], [], 500)
@@ -44,7 +44,7 @@ defmodule Membrane.Core.MessageTest do
 
     test "crash when receiver process is not alive" do
       Process.flag(:trap_exit, true)
-      pid = spawn_link(fn -> 5 end)
+      pid = spawn_link(fn -> :ok end)
       assert_receive {:EXIT, ^pid, :normal}
 
       caller_pid =

--- a/test/membrane/core/message_test.exs
+++ b/test/membrane/core/message_test.exs
@@ -1,0 +1,31 @@
+defmodule Membrane.Core.MessageTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.Core.Message
+
+  require Membrane.Core.Message
+
+  defmodule Receiver do
+    use GenServer
+
+    @impl GenServer
+    def init(_opts), do: {:ok, nil}
+
+    @impl GenServer
+    def handle_call(Message.new(:request), _from, state), do: {:reply, :ok, state}
+  end
+
+  test "receiver process alive" do
+    {:ok, receiver} = GenServer.start_link(Receiver, [])
+
+    response = Message.call(receiver, :request)
+
+    assert response == :ok
+  end
+
+  test "receiver process not alive" do
+    response = Message.call(:c.pid(0, 255, 0), :request, [], [], 500)
+
+    assert match?({:error, _reason}, response)
+  end
+end


### PR DESCRIPTION
This PR refactors `Message.call` to return an error instead of exiting when the receiver process is not alive.