### PR TITLE
Update link_handler.ex

### DIFF
--- a/lib/membrane/core/parent/child_life_controller/link_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_handler.ex
@@ -45,9 +45,8 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkHandler do
     {links, state} =
       Enum.map_reduce(links, state, fn link, state ->
         link = %Link{
-          link
-          | from: resolve_endpoint(link.from, state),
-            to: resolve_endpoint(link.to, state)
+          from: resolve_endpoint(link.from, state),
+          to: resolve_endpoint(link.to, state)
         }
 
         link_id = {spec_ref, make_ref()}


### PR DESCRIPTION
It seems that `%Link{}` has only `from` and `to` fields according to the type spec.
https://github.com/membraneframework/membrane_core/blob/master/lib/membrane/core/parent/link.ex