### PR TITLE
add crash group down assertion to Testing.Pipeline and code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
  * Added log metadata when reporting init in telemetry [#376](https://github.com/membraneframework/membrane_core/pull/376)
  * Fix generation of pad documentation inside an element [#377](https://github.com/membraneframework/membrane_core/pull/377)
  * Leaving static pads unlinked and transiting to a playback state other than `:stopped` will result
- in runtime error (previously only a warning was printed out). [##389](https://github.com/membraneframework/membrane_core/pull/389)
+ in runtime error (previously only a warning was printed out). [#389](https://github.com/membraneframework/membrane_core/pull/389)
+ * It is possible now to assert on crash group down when using Testing.Pipeline. [#391](https://github.com/membraneframework/membrane_core/pull/391)
 
 ## 0.8.2
  * Fixed PadAdded spec [#359](https://github.com/membraneframework/membrane_core/pull/359)

--- a/lib/membrane/testing/assertions.ex
+++ b/lib/membrane/testing/assertions.ex
@@ -93,6 +93,56 @@ defmodule Membrane.Testing.Assertions do
   end
 
   @doc """
+  Asserts that a crash group within pipeline will be down within the `timeout` period specified in
+  milliseconds.
+
+  Usage example:
+
+      assert_pipeline_crash_group_down(pipeline, :group_1)
+  """
+  defmacro assert_pipeline_crash_group_down(pipeline, group_name, timeout \\ @default_timeout) do
+    quote do
+      group_name_value = unquote(group_name)
+
+      unquote(
+        assert_receive_from_pipeline(
+          pipeline,
+          {:handle_crash_group_down,
+           quote do
+             ^group_name_value
+           end},
+          timeout
+        )
+      )
+    end
+  end
+
+  @doc """
+  Refutes that a crash group within pipeline won't be down within the `timeout` period specified in
+  milliseconds.
+
+  Usage example:
+
+      refute_pipeline_crash_group_down(pipeline, :group_1)
+  """
+  defmacro refute_pipeline_crash_group_down(pipeline, group_name, timeout \\ @default_timeout) do
+    quote do
+      group_name_value = unquote(group_name)
+
+      unquote(
+        refute_receive_from_pipeline(
+          pipeline,
+          {:handle_crash_group_down,
+           quote do
+             ^group_name_value
+           end},
+          timeout
+        )
+      )
+    end
+  end
+
+  @doc """
   Asserts that pipeline's playback state (see `Membrane.PlaybackState`)
   changed or will change from `previous_state` to `current_state` within
   the `timeout` period specified in milliseconds.

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -277,58 +277,58 @@ defmodule Membrane.Testing.Pipeline do
 
   @impl true
   def handle_stopped_to_prepared(ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_stopped_to_prepared,
         [ctx],
         state
       )
 
-    testing_pipeline_result = notify_playback_state_changed(:stopped, :prepared, state)
+    :ok = notify_playback_state_changed(state.test_process, :stopped, :prepared)
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_prepared_to_playing(ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_prepared_to_playing,
         [ctx],
         state
       )
 
-    testing_pipeline_result = notify_playback_state_changed(:prepared, :playing, state)
+    :ok = notify_playback_state_changed(state.test_process, :prepared, :playing)
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_playing_to_prepared(ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_playing_to_prepared,
         [ctx],
         state
       )
 
-    testing_pipeline_result = notify_playback_state_changed(:playing, :prepared, state)
+    :ok = notify_playback_state_changed(state.test_process, :playing, :prepared)
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_prepared_to_stopped(ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_prepared_to_stopped,
         [ctx],
         state
       )
 
-    testing_pipeline_result = notify_playback_state_changed(:prepared, :stopped, state)
+    :ok = notify_playback_state_changed(state.test_process, :prepared, :stopped)
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
@@ -338,36 +338,34 @@ defmodule Membrane.Testing.Pipeline do
         _ctx,
         %State{} = state
       ) do
-    notify_test_process({:handle_notification, {notification, from}}, state)
+    :ok = notify_test_process(state.test_process, {:handle_notification, {notification, from}})
+    {:ok, state}
   end
 
   @impl true
   def handle_notification(notification, from, ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_notification,
         [notification, from, ctx],
         state
       )
 
-    testing_pipeline_result =
-      notify_test_process({:handle_notification, {notification, from}}, state)
+    :ok = notify_test_process(state.test_process, {:handle_notification, {notification, from}})
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_spec_started(elements, ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_spec_started,
         [elements, ctx],
         state
       )
 
-    testing_pipeline_result = {:ok, state}
-
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
@@ -399,74 +397,70 @@ defmodule Membrane.Testing.Pipeline do
 
   @impl true
   def handle_other(message, ctx, %State{} = state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_other,
         [message, ctx],
         state
       )
 
-    testing_pipeline_result = notify_test_process({:handle_other, message}, state)
+    :ok = notify_test_process(state.test_process, {:handle_other, message})
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_element_start_of_stream(endpoint, ctx, state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_element_start_of_stream,
         [endpoint, ctx],
         state
       )
 
-    testing_pipeline_result =
-      notify_test_process({:handle_element_start_of_stream, endpoint}, state)
+    :ok = notify_test_process(state.test_process, {:handle_element_start_of_stream, endpoint})
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_element_end_of_stream(endpoint, ctx, state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_element_end_of_stream,
         [endpoint, ctx],
         state
       )
 
-    testing_pipeline_result =
-      notify_test_process({:handle_element_end_of_stream, endpoint}, state)
+    :ok = notify_test_process(state.test_process, {:handle_element_end_of_stream, endpoint})
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_tick(timer, ctx, state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_tick,
         [timer, ctx],
         state
       )
 
-    testing_pipeline_result = {:ok, state}
-
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   @impl true
   def handle_crash_group_down(group_name, ctx, state) do
-    injected_module_result =
+    {custom_actions, custom_state} =
       eval_injected_module_callback(
         :handle_crash_group_down,
         [group_name, ctx],
         state
       )
 
-    testing_pipeline_result = {:ok, state}
+    :ok = notify_test_process(state.test_process, {:handle_crash_group_down, group_name})
 
-    combine_results(injected_module_result, testing_pipeline_result)
+    {custom_actions, Map.put(state, :custom_pipeline_state, custom_state)}
   end
 
   defp default_options(%Options{test_process: nil} = options),
@@ -483,13 +477,13 @@ defmodule Membrane.Testing.Pipeline do
     apply(state.module, callback, args ++ [state.custom_pipeline_state]) |> unify_result()
   end
 
-  defp notify_playback_state_changed(previous, current, %State{} = state) do
-    notify_test_process({:playback_state_changed, previous, current}, state)
+  defp notify_playback_state_changed(test_process, previous, current) do
+    notify_test_process(test_process, {:playback_state_changed, previous, current})
   end
 
-  defp notify_test_process(message, %State{test_process: test_process} = state) do
+  defp notify_test_process(test_process, message) do
     send(test_process, {__MODULE__, self(), message})
-    {:ok, state}
+    :ok
   end
 
   defp unify_result({:ok, state}),

--- a/test/membrane/integration/child_crash_test.exs
+++ b/test/membrane/integration/child_crash_test.exs
@@ -68,7 +68,7 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pid_alive(sink_pid)
     assert_pid_alive(pipeline_pid)
 
-    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
+    assert_pipeline_crash_group_down(pipeline_pid, 1)
   end
 
   test "Crash group consisting of bin crashes" do
@@ -191,8 +191,8 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pid_alive(source_2_pid)
     assert_pid_alive(pipeline_pid)
 
-    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 1})
-    refute_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 2})
+    assert_pipeline_crash_group_down(pipeline_pid, 1)
+    refute_pipeline_crash_group_down(pipeline_pid, 2)
 
     ChildCrashTest.Pipeline.crash_child(filter_1_2_pid)
 
@@ -206,7 +206,7 @@ defmodule Membrane.Integration.ChildCrashTest do
     assert_pid_alive(center_filter_pid)
     assert_pid_alive(pipeline_pid)
 
-    assert_pipeline_receive(pipeline_pid, {:handle_crash_group_called, 2})
+    assert_pipeline_crash_group_down(pipeline_pid, 2)
   end
 
   defp assert_pid_alive(pid) do

--- a/test/support/child_crash_test/pipeline.ex
+++ b/test/support/child_crash_test/pipeline.ex
@@ -40,17 +40,6 @@ defmodule Membrane.Support.ChildCrashTest.Pipeline do
     {{:ok, spec: spec}, state}
   end
 
-  @impl true
-  def handle_other({:handle_crash_group_called, _group_name}, _ctx, state) do
-    {:ok, state}
-  end
-
-  @impl true
-  def handle_crash_group_down(group_name, _ctx, state) do
-    send(self(), {:handle_crash_group_called, group_name})
-    {:ok, state}
-  end
-
   @spec add_single_source(pid(), any(), any(), any()) :: any()
   def add_single_source(pid, source_name, group \\ nil, source \\ Testing.Source) do
     children = [


### PR DESCRIPTION
This PR: 
* leaves `combine_results` only in places where is it necessary,
* makes the `Testing.Pipeline` to notify the testing process when the crash group is down,
* adds `assert_pipeline_crash_group_down` and `refute_pipeline_crash_group_down` assertions
* updates `child_crash_test` to use new assertions.
