### PR TITLE
Improve error printed when handle_init fails

### DIFF
--- a/lib/membrane/core/parent/child_life_controller/startup_handler.ex
+++ b/lib/membrane/core/parent/child_life_controller/startup_handler.ex
@@ -205,10 +205,14 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupHandler do
          {:ok, clock} <- Message.call(pid, :get_clock) do
       %ChildEntry{child | pid: pid, clock: clock, sync: sync}
     else
+      {:error, {error, stacktrace}} when is_exception(error) ->
+        reraise error, stacktrace
+
       {:error, reason} ->
-        raise ParentError,
-              "Cannot start child #{inspect(name)}, \
-              reason: #{inspect(reason, pretty: true)}"
+        raise ParentError, """
+        Cannot start child #{inspect(name)},
+        reason: #{inspect(reason, pretty: true)}
+        """
     end
   end
 end


### PR DESCRIPTION
* Raise inside handle_init
  * before: 
  ```
     ** (EXIT from #PID<0.369.0>) an exception was raised:
         ** (Membrane.ParentError) Cannot start child :parser,               reason: {%RuntimeError{message: "Unsupported frame format: rgb"},
      [
        {Membrane.RawVideo.Parser, :handle_init, 1,
         [
           file: 'lib/membrane_raw_video/parser.ex',
           line: 51,
           error_info: %{module: Exception}
         ]},
        {Membrane.Core.CallbackHandler, :exec_callback, 4,
         [file: 'lib/membrane/core/callback_handler.ex', line: 113]},
        {Membrane.Core.CallbackHandler, :exec_and_handle_callback, 5,
         [file: 'lib/membrane/core/callback_handler.ex', line: 71]},
        {Membrane.Core.Element.LifecycleController, :handle_init, 2,
         [file: 'lib/membrane/core/element/lifecycle_controller.ex', line: 46]},
        {Membrane.Core.Element, :init, 1,
         [file: 'lib/membrane/core/element.ex', line: 113]},
        {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 423]},
        {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 390]},
        {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}
      ]}
             (membrane_core 0.9.0) lib/membrane/core/parent/child_life_controller/startup_handler.ex:209: Membrane.Core.Parent.ChildLifeController.StartupHandler.start_child/5
             (elixir 1.13.1) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
             (elixir 1.13.1) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
             (membrane_core 0.9.0) lib/membrane/core/parent/child_life_controller.ex:43: Membrane.Core.Parent.ChildLifeController.handle_spec/2
             (membrane_core 0.9.0) lib/membrane/core/pipeline/action_handler.ex:63: Membrane.Core.Pipeline.ActionHandler.do_handle_action/4
             (membrane_core 0.9.0) lib/membrane/core/pipeline/action_handler.ex:30: Membrane.Core.Pipeline.ActionHandler.handle_action/4
             (bunch 1.3.0) lib/bunch/enum.ex:121: anonymous fn/3 in Bunch.Enum.try_reduce/3
             (elixir 1.13.1) lib/enum.ex:4475: Enumerable.List.reduce/3
             (elixir 1.13.1) lib/enum.ex:2442: Enum.reduce_while/3
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:162: Membrane.Core.CallbackHandler.exec_handle_actions/5
             (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
             (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
             (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
  ```
  * after:
  ```
       ** (EXIT from #PID<0.363.0>) an exception was raised:
         ** (RuntimeError) Unsupported frame format: rgb
             (membrane_raw_video_parser_plugin 0.6.0) lib/membrane_raw_video/parser.ex:51: Membrane.RawVideo.Parser.handle_init/1
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:113: Membrane.Core.CallbackHandler.exec_callback/4
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:71: Membrane.Core.CallbackHandler.exec_and_handle_callback/5
             (membrane_core 0.9.0) lib/membrane/core/element/lifecycle_controller.ex:46: Membrane.Core.Element.LifecycleController.handle_init/2
             (membrane_core 0.9.0) lib/membrane/core/element.ex:113: Membrane.Core.Element.init/1
             (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
             (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
             (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
  ```
* error returned from `handle_init`
  * before
  ```
     ** (EXIT from #PID<0.336.0>) an exception was raised:
         ** (Membrane.ParentError) Cannot start child :parser,               reason: {%Membrane.CallbackError{
        message: "Error returned from Membrane.RawVideo.Parser.handle_init:\n:invalid_dims\n"
      },
      [
        {Membrane.Core.CallbackHandler, :parse_callback_result, 3,
         [file: 'lib/membrane/core/callback_handler.ex', line: 184]},
        {Membrane.Core.CallbackHandler, :exec_and_handle_callback, 5,
         [file: 'lib/membrane/core/callback_handler.ex', line: 71]},
        {Membrane.Core.Element.LifecycleController, :handle_init, 2,
         [file: 'lib/membrane/core/element/lifecycle_controller.ex', line: 46]},
        {Membrane.Core.Element, :init, 1,
         [file: 'lib/membrane/core/element.ex', line: 113]},
        {:gen_server, :init_it, 2, [file: 'gen_server.erl', line: 423]},
        {:gen_server, :init_it, 6, [file: 'gen_server.erl', line: 390]},
        {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 226]}
      ]}
             (membrane_core 0.9.0) lib/membrane/core/parent/child_life_controller/startup_handler.ex:209: Membrane.Core.Parent.ChildLifeController.StartupHandler.start_child/5
             (elixir 1.13.1) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
             (elixir 1.13.1) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
             (membrane_core 0.9.0) lib/membrane/core/parent/child_life_controller.ex:43: Membrane.Core.Parent.ChildLifeController.handle_spec/2
             (membrane_core 0.9.0) lib/membrane/core/pipeline/action_handler.ex:63: Membrane.Core.Pipeline.ActionHandler.do_handle_action/4
             (membrane_core 0.9.0) lib/membrane/core/pipeline/action_handler.ex:30: Membrane.Core.Pipeline.ActionHandler.handle_action/4
             (bunch 1.3.0) lib/bunch/enum.ex:121: anonymous fn/3 in Bunch.Enum.try_reduce/3
             (elixir 1.13.1) lib/enum.ex:4475: Enumerable.List.reduce/3
             (elixir 1.13.1) lib/enum.ex:2442: Enum.reduce_while/3
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:162: Membrane.Core.CallbackHandler.exec_handle_actions/5
             (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
             (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
             (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
  ```
  * after
  ```
     ** (EXIT from #PID<0.363.0>) an exception was raised:
         ** (Membrane.CallbackError) Error returned from Membrane.RawVideo.Parser.handle_init:
     :invalid_dims
     
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:184: Membrane.Core.CallbackHandler.parse_callback_result/3
             (membrane_core 0.9.0) lib/membrane/core/callback_handler.ex:71: Membrane.Core.CallbackHandler.exec_and_handle_callback/5
             (membrane_core 0.9.0) lib/membrane/core/element/lifecycle_controller.ex:46: Membrane.Core.Element.LifecycleController.handle_init/2
             (membrane_core 0.9.0) lib/membrane/core/element.ex:113: Membrane.Core.Element.init/1
             (stdlib 3.17) gen_server.erl:423: :gen_server.init_it/2
             (stdlib 3.17) gen_server.erl:390: :gen_server.init_it/6
             (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
  ```