### PR TITLE
Remote controlled pipeline improved

### DIFF
--- a/lib/membrane/remote_controlled/message.ex
+++ b/lib/membrane/remote_controlled/message.ex
@@ -11,6 +11,7 @@ defmodule Membrane.RemoteControlled.Message do
             | Membrane.RemoteControlled.Message.StartOfStream.t()
             | Membrane.RemoteControlled.Message.EndOfStream.t()
             | Membrane.RemoteControlled.Message.Notification.t()
+            | Membrane.RemoteControlled.Message.Terminated.t()
         }
 
   @enforce_keys [:from, :body]
@@ -53,6 +54,16 @@ defmodule Membrane.RemoteControlled.Message do
     @type t :: %__MODULE__{element: Membrane.Element.name_t(), data: Membrane.Notification.t()}
 
     @enforce_keys [:element, :data]
+    defstruct @enforce_keys
+  end
+
+  defmodule Terminated do
+    @moduledoc """
+    Message sent when the pipeline is terminated.
+    """
+    @type t :: %__MODULE__{reason: :normal | :shutdown | {:shutdown, any()} | term()}
+
+    @enforce_keys [:reason]
     defstruct @enforce_keys
   end
 end

--- a/lib/membrane/remote_controlled/message.ex
+++ b/lib/membrane/remote_controlled/message.ex
@@ -1,0 +1,58 @@
+defmodule Membrane.RemoteControlled.Message do
+  @moduledoc """
+  A module defining the structure of the message which can be received by the pipeline.
+  This structure wraps the specific message type instance (i.e. Message.PlaybackState message) inside the `body` field
+  and provides an additional `:from` field with the pid of the message sender.
+  """
+  @type t :: %__MODULE__{
+          from: pid(),
+          body:
+            Membrane.RemoteControlled.Message.PlaybackState.t()
+            | Membrane.RemoteControlled.Message.StartOfStream.t()
+            | Membrane.RemoteControlled.Message.EndOfStream.t()
+            | Membrane.RemoteControlled.Message.Notification.t()
+        }
+
+  @enforce_keys [:from, :body]
+  defstruct @enforce_keys
+
+  defmodule PlaybackState do
+    @moduledoc """
+    Message sent when the pipeline changes its playback state
+    """
+    @type t :: %__MODULE__{state: Membrane.PlaybackState.t()}
+
+    @enforce_keys [:state]
+    defstruct @enforce_keys
+  end
+
+  defmodule StartOfStream do
+    @moduledoc """
+    Message sent when some element of the pipeline receives the start of stream event on some pad.
+    """
+    @type t :: %__MODULE__{element: Membrane.Element.name_t(), pad: Membrane.Pad.name_t()}
+
+    @enforce_keys [:element, :pad]
+    defstruct @enforce_keys
+  end
+
+  defmodule EndOfStream do
+    @moduledoc """
+    Message sent when some element of the pipeline receives the start of stream event on some pad.
+    """
+    @type t :: %__MODULE__{element: Membrane.Element.name_t(), pad: Membrane.Pad.name_t()}
+
+    @enforce_keys [:element, :pad]
+    defstruct @enforce_keys
+  end
+
+  defmodule Notification do
+    @moduledoc """
+    Message sent when the some element of the pipeline receives a notification.
+    """
+    @type t :: %__MODULE__{element: Membrane.Element.name_t(), data: Membrane.Notification.t()}
+
+    @enforce_keys [:element, :data]
+    defstruct @enforce_keys
+  end
+end

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -19,7 +19,6 @@ defmodule Membrane.RemoteControlled.Pipeline do
   alias Membrane.Pipeline
   alias Membrane.RemoteControlled.Message
 
-
   defmodule State do
     @moduledoc false
 

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -19,6 +19,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   alias Membrane.Pipeline
   alias Membrane.RemoteControlled.Message
 
+  alias Membrane.RemoteControlled.Message.{
+    PlaybackState,
+    StartOfStream,
+    EndOfStream,
+    Notification
+  }
+
   defmodule State do
     @moduledoc false
 
@@ -65,7 +72,7 @@ defmodule Membrane.RemoteControlled.Pipeline do
       receive do
         %Message{
           from: ^unquote(pipeline),
-          body: %Membrane.RemoteControlled.Message.unquote(message_type){
+          body: %unquote(message_type){
             unquote_splicing(Macro.expand(keywords, __ENV__))
           }
         } = msg ->
@@ -75,10 +82,16 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with no further constraints,
-  sent by the process with `pipeline` pid.
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()`
+  message with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for any playback state change occuring in the pipeline:
+    ```
+    Pipeline.await_playback_state(pipeline)
+    ```
   """
   @spec await_playback_state(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_playback_state(pipeline) do
@@ -86,10 +99,16 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with the given `state`,
-  sent by the process with `pipeline` pid.
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()`
+  message with the given `state`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the pipeline's playback state to change into `:playing`:
+    ```
+    Pipeline.await_playback_state(pipeline, :playing)
+    ```
   """
   @spec await_playback_state(pid, Membrane.PlaybackState.t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -102,6 +121,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `start_of_stream` occuring on any pad of any element in the pipeline:
+    ```
+    Pipeline.await_start_of_stream(pipeline)
+    ```
   """
   @spec await_start_of_stream(pid) :: Membrane.RemoteControlled.Message.t()
   def await_start_of_stream(pipeline) do
@@ -113,6 +138,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `start_of_stream` occuring on any pad of the `:element_id` element in the pipeline:
+    ```
+    Pipeline.await_start_of_stream(pipeline, :element_id)
+    ```
   """
   @spec await_start_of_stream(pid(), Membrane.Element.name_t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -125,6 +156,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `start_of_stream` occuring on the `:pad_id` pad of the `:element_id` element in the pipeline:
+    ```
+    Pipeline.await_start_of_stream(pipeline, :element_id, :pad_id)
+    ```
   """
   @spec await_start_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -137,6 +174,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `end_of_stream` occuring on any pad of any element in the pipeline:
+    ```
+    Pipeline.await_end_of_stream(pipeline)
+    ```
   """
   @spec await_end_of_stream(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_end_of_stream(pipeline) do
@@ -148,6 +191,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `end_of_stream` occuring on any pad of the `:element_id` element in the pipeline:
+    ```
+    Pipeline.await_end_of_stream(pipeline, :element_id)
+    ```
   """
   @spec await_end_of_stream(pid(), Membrane.Element.name_t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -160,6 +209,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first `end_of_stream` occuring on the `:pad_id` of the `:element_id` element in the pipeline:
+    ```
+    Pipeline.await_end_of_stream(pipeline, :element_id, :pad_id)
+    ```
   """
   @spec await_end_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -172,6 +227,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   message with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first notification send to any element in the pipeline:
+    ```
+    Pipeline.await_notification(pipeline)
+    ```
   """
   @spec await_notification(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_notification(pipeline) do
@@ -183,6 +244,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
+
+  Usage example:
+    1) awaiting for the first notification send to the `:element_id` element in the pipeline:
+    ```
+    Pipeline.await_notification(pipeline, :element_id)
+    ```
   """
   @spec await_notification(pid(), Membrane.Notification.t()) ::
           Membrane.RemoteControlled.Message.t()
@@ -195,10 +262,21 @@ defmodule Membrane.RemoteControlled.Pipeline do
   of elements of `Membrane.RemoteControlled.Pipeline.message_t()` type. The `subscription_pattern`
   must be a match pattern.
 
-      subscribe(pid, {:playback_state, _})
 
-  Such call would make the `Membrane.RemoteControlled.Pipeline` to send all `:playback_state` messages
-  to the controlling process.
+  Usage examples:
+  1) making the `Membrane.RemoteControlled.Pipeline` send to the controlling process `Message.StartOfStream` message
+    when any pad of the `:element_id` receives `:start_of_stream` event.
+
+    ```
+    subscribe(pipeline, %Message.StartOfStream{element: :element_id, pad: _})
+    ```
+
+  2) making the `Membrane.RemoteControlled.Pipeline` send to the controlling process `Message.PlaybackState` message when the pipeline playback state changes to any state
+    (that is - for all the :stopped, :prepared and :playing playback states).
+
+    ```
+    subscribe(pipeline, %Message.PlaybackState{state: _})
+    ```
   """
   defmacro subscribe(pipeline, subscription_pattern) do
     quote do
@@ -212,13 +290,15 @@ defmodule Membrane.RemoteControlled.Pipeline do
   @doc """
   Sends a list of `Pipeline.Action.t()` to the given `Membrane.RemoteControlled.Pipeline` for execution.
 
+  Usage example:
+    1) making the `Membrane.RemoteControlled.Pipeline` start the `Membrane.ParentSpec`
+       specified in the action.
+      ```
       children = ...
       links = ...
       actions = [{:spec, %ParentSpec{children: children, links: links}}]
       Pipeline.exec_actions(pipeline, actions)
-
-  Such a call would make the `Membrane.RemoteControlled.Pipeline` to start the `Membrane.ParentSpec`
-  specified in the action.
+      ```
   """
   @spec exec_actions(pid(), [Pipeline.Action.t()]) :: :ok
   def exec_actions(pipeline, actions) do

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -58,7 +58,7 @@ defmodule Membrane.RemoteControlled.Pipeline do
 
         case args do
           nil -> {:^, ctx, [node]}
-          _ -> node
+          _not_nil -> node
         end
       else
         node

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -139,6 +139,25 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
 
+
+  defmacro await_generic(message_type, keywords\\[]) do
+    quote do
+      receive do
+        %Membrane.RemoteControlled.Pipeline.Message.unquote(message_type){unquote_splicing(Macro.expand(keywords, __ENV__))} = msg -> msg
+      end
+    end
+  end
+
+
+  @spec await_generic2(any) :: {:receive, [], [[{any, any}, ...], ...]}
+  defmacro await_generic2(message) do
+    quote do
+      receive do
+        unquote(Macro.expand(message, __ENV__)) = msg -> msg
+      end
+    end
+  end
+
   @doc """
   Subscribes to a given `subscription_pattern`. The `subscription_pattern` should describe some subset
   of elements of `Membrane.RemoteControlled.Pipeline.message_t()` type. The `subscription_pattern`
@@ -253,23 +272,5 @@ defmodule Membrane.RemoteControlled.Pipeline do
       send(state.controller_pid, message)
     end
   end
-
-
-
-  # defp do_pattern_match?(event, pattern) do
-  #   event_as_list = event |> Tuple.to_list()
-  #   pattern_as_list = pattern |> Tuple.to_list()
-  #   event_as_list |> Enum.slice(0..length(pattern_as_list)) |> Enum.zip(pattern_as_list) |>
-  #     Enum.all?(fn {event_at_given_position, pattern_at_given_position}-> do_pattern_match_at_given_position?(event_at_given_position, pattern_at_given_position) end)
-  # end
-
-  # defp do_pattern_match_at_given_position?(_event_at_given_position, pattern_at_given_position) when pattern_at_given_position==:any do
-  #   true
-  # end
-
-  # defp do_pattern_match_at_given_position?(event_at_given_position, pattern_at_given_position) do
-  #   event_at_given_position==pattern_at_given_position
-  # end
-
 
 end

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -43,173 +43,22 @@ defmodule Membrane.RemoteControlled.Pipeline do
     Pipeline.start(__MODULE__, %{controller_pid: self()}, process_options)
   end
 
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with no further constraints,
-  sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_playback_state(pid()) :: Membrane.RemoteControlled.Message.t()
-  def await_playback_state(pipeline) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.PlaybackState{}} = message ->
-        message
-    end
+  defp pin_leaf_nodes(ast) do
+    Macro.postwalk(ast, fn node ->
+      if not Macro.quoted_literal?(node) and match?({_name, _ctx, _args}, node) do
+        {_name, ctx, args} = node
+
+        case args do
+          nil -> {:^, ctx, [node]}
+          _ -> node
+        end
+      else
+        node
+      end
+    end)
   end
 
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with the given `state`,
-  sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_playback_state(pid, Membrane.PlaybackState.t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_playback_state(pipeline, playback_state) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.PlaybackState{state: ^playback_state}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
-  with no further constraints, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_start_of_stream(pid) :: Membrane.RemoteControlled.Message.t()
-  def await_start_of_stream(pipeline) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.StartOfStream{}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
-  concerning the given `element`, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_start_of_stream(pid(), Membrane.Element.name_t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_start_of_stream(pipeline, element) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.StartOfStream{element: ^element}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
-  concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_start_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_start_of_stream(pipeline, element, pad) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.StartOfStream{element: ^element, pad: ^pad}} =
-          message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
-  with no further constraints, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_end_of_stream(pid()) :: Membrane.RemoteControlled.Message.t()
-  def await_end_of_stream(pipeline) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.EndOfStream{}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
-  concerning the given `element`, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_end_of_stream(pid(), Membrane.Element.name_t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_end_of_stream(pipeline, element) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.EndOfStream{element: ^element}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
-  concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_end_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_end_of_stream(pipeline, element, pad) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.EndOfStream{element: ^element, pad: ^pad}} =
-          message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()`
-  message with no further constraints, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_notification(pid()) :: Membrane.RemoteControlled.Message.t()
-  def await_notification(pipeline) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.Notification{}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()` message
-  concerning the given `element`, sent by the process with `pipeline` pid.
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  @spec await_notification(pid(), Membrane.Notification.t()) ::
-          Membrane.RemoteControlled.Message.t()
-  def await_notification(pipeline, element) do
-    receive do
-      %Message{from: ^pipeline, body: %Message.Notification{element: ^element}} = message ->
-        message
-    end
-  end
-
-  @doc """
-  Awaits for a `Membrane.RemoteControlled.Message()` wrapping the given `message_type`, with some fields specified according to the `keywords` list, sent by the
-  process with the `pipeline` pid.
-
-  Arguments:
-    pipeline - pid of the pipeline process
-    message_type - an atom describing the desired message type (i.e. PlaybackState or Notification)
-    keywords - keywords list with keys being the field names of the given `message_type` structure.
-
-  Exemplary usage:
-    `await_generic(pipeline, StartOfStream, element: :b)`
-
-    Such a call would await for the first message matching the following pattern: `%Message{from: ^pipeline, body: Message.StartOfStream{element: :b}}`
-    Note, that a message would will matched independently of the value of the `:input` field of the `Message.StartOfStream` structure.
-
-  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
-  for that message.
-  """
-  defmacro await_generic(pipeline, message_type, keywords \\ []) do
+  defmacrop do_await(pipeline, message_type, keywords \\ []) do
     keywords = pin_leaf_nodes(keywords)
 
     quote do
@@ -226,35 +75,119 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for a `Membrane.RemoteControlled.Message()`, which `:body` field matches the given `message_pattern`, sent by the
-  process with the `pipeline` pid.
-
-  Arguments:
-    pipeline - pid of the pipeline process
-    message_pattern - an pattern describing the desired specific message (i.e. %PlaybackState{state: :playing}). If values of some specific messages field are irrevelant then those fields should be omited
-    (usage of a wildcard `_` sign will result in compilation error)
-
-  Exemplary usage:
-    `await_generic(pipeline, %StartOfStream{element: :b})`
-
-    Such a call would await for the first message matching the following pattern: `%Message{from: ^pipeline, body: Message.StartOfStream{element: :b}}`
-    Note, that a message will be matched independently of the value of the `:input` field of the `Message.StartOfStream` structure.
-
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with no further constraints,
+  sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
-  defmacro await_generic_with_alternative_syntax(pipeline, message_pattern) do
-    message_pattern = pin_leaf_nodes(message_pattern)
+  @spec await_playback_state(pid()) :: Membrane.RemoteControlled.Message.t()
+  def await_playback_state(pipeline) do
+    do_await(pipeline, PlaybackState)
+  end
 
-    quote do
-      receive do
-        %Message{
-          from: ^unquote(Macro.expand(pipeline, __ENV__)),
-          body: unquote(Macro.expand(message_pattern, __ENV__))
-        } = msg ->
-          msg
-      end
-    end
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with the given `state`,
+  sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_playback_state(pid, Membrane.PlaybackState.t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_playback_state(pipeline, playback_state) do
+    do_await(pipeline, PlaybackState, state: playback_state)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
+  with no further constraints, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_start_of_stream(pid) :: Membrane.RemoteControlled.Message.t()
+  def await_start_of_stream(pipeline) do
+    do_await(pipeline, StartOfStream)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
+  concerning the given `element`, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_start_of_stream(pid(), Membrane.Element.name_t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_start_of_stream(pipeline, element) do
+    do_await(pipeline, StartOfStream, element: element)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
+  concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_start_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_start_of_stream(pipeline, element, pad) do
+    do_await(pipeline, StartOfStream, element: element, pad: pad)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
+  with no further constraints, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_end_of_stream(pid()) :: Membrane.RemoteControlled.Message.t()
+  def await_end_of_stream(pipeline) do
+    do_await(pipeline, EndOfStream)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
+  concerning the given `element`, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_end_of_stream(pid(), Membrane.Element.name_t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_end_of_stream(pipeline, element) do
+    do_await(pipeline, EndOfStream, element: element)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
+  concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_end_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_end_of_stream(pipeline, element, pad) do
+    do_await(pipeline, EndOfStream, element: element, pad: pad)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()`
+  message with no further constraints, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_notification(pid()) :: Membrane.RemoteControlled.Message.t()
+  def await_notification(pipeline) do
+    do_await(pipeline, Notification)
+  end
+
+  @doc """
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()` message
+  concerning the given `element`, sent by the process with `pipeline` pid.
+  It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
+  for that message.
+  """
+  @spec await_notification(pid(), Membrane.Notification.t()) ::
+          Membrane.RemoteControlled.Message.t()
+  def await_notification(pipeline, element) do
+    do_await(pipeline, Notification, element: element)
   end
 
   @doc """
@@ -382,20 +315,5 @@ defmodule Membrane.RemoteControlled.Pipeline do
     if Enum.any?(state.matching_functions, & &1.(message)) do
       send(state.controller_pid, message)
     end
-  end
-
-  defp pin_leaf_nodes(ast) do
-    Macro.postwalk(ast, fn node ->
-      if not Macro.quoted_literal?(node) and match?({_name, _ctx, _args}, node) do
-        {_name, ctx, args} = node
-
-        case args do
-          nil -> {:^, ctx, [node]}
-          _ -> node
-        end
-      else
-        node
-      end
-    end)
   end
 end

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -51,19 +51,21 @@ defmodule Membrane.RemoteControlled.Pipeline do
     Pipeline.start(__MODULE__, %{controller_pid: self()}, process_options)
   end
 
-  defp pin_leaf_nodes(ast) do
-    Macro.postwalk(ast, fn node ->
-      if not Macro.quoted_literal?(node) and match?({_name, _ctx, _args}, node) do
-        {_name, ctx, args} = node
+  defmacrop pin_leaf_nodes(ast) do
+    quote do
+      Macro.postwalk(unquote(ast), fn node ->
+        if not Macro.quoted_literal?(node) and match?({_name, _ctx, _args}, node) do
+          {_name, ctx, args} = node
 
-        case args do
-          nil -> {:^, ctx, [node]}
-          _not_nil -> node
+          case args do
+            nil -> {:^, ctx, [node]}
+            _not_nil -> node
+          end
+        else
+          node
         end
-      else
-        node
-      end
-    end)
+      end)
+    end
   end
 
   defmacrop do_await(pipeline, message_type, keywords \\ []) do

--- a/lib/membrane/remote_controlled/pipeline.ex
+++ b/lib/membrane/remote_controlled/pipeline.ex
@@ -17,65 +17,8 @@ defmodule Membrane.RemoteControlled.Pipeline do
   use Membrane.Pipeline
 
   alias Membrane.Pipeline
+  alias Membrane.RemoteControlled.Message
 
-  defmodule Message do
-    @moduledoc """
-    A module defining the structure of the message which can be received by the pipeline.
-    This structure wraps the specific message type instance (i.e. Message.PlaybackState message) inside the `body` field
-    and provides an additional `:from` field with the pid of the message sender.
-    """
-    @type t :: %__MODULE__{
-            from: pid(),
-            body:
-              Membrane.RemoteControlled.Pipeline.Message.PlaybackState.t()
-              | Membrane.RemoteControlled.Pipeline.Message.StartOfStream.t()
-              | Membrane.RemoteControlled.Pipeline.Message.EndOfStream.t()
-              | Membrane.RemoteControlled.Pipeline.Message.Notification.t()
-          }
-
-    @enforce_keys [:from, :body]
-    defstruct @enforce_keys
-
-    defmodule PlaybackState do
-      @moduledoc """
-      Message sent when the pipeline changes its playback state
-      """
-      @type t :: %__MODULE__{state: Membrane.PlaybackState.t()}
-
-      @enforce_keys [:state]
-      defstruct @enforce_keys
-    end
-
-    defmodule StartOfStream do
-      @moduledoc """
-      Message sent when some element of the pipeline receives the start of stream event on some pad.
-      """
-      @type t :: %__MODULE__{element: Membrane.Element.name_t(), pad: Membrane.Pad.name_t()}
-
-      @enforce_keys [:element, :pad]
-      defstruct @enforce_keys
-    end
-
-    defmodule EndOfStream do
-      @moduledoc """
-      Message sent when some element of the pipeline receives the start of stream event on some pad.
-      """
-      @type t :: %__MODULE__{element: Membrane.Element.name_t(), pad: Membrane.Pad.name_t()}
-
-      @enforce_keys [:element, :pad]
-      defstruct @enforce_keys
-    end
-
-    defmodule Notification do
-      @moduledoc """
-      Message sent when the some element of the pipeline receives a notification.
-      """
-      @type t :: %__MODULE__{element: Membrane.Element.name_t(), data: Membrane.Notification.t()}
-
-      @enforce_keys [:element, :data]
-      defstruct @enforce_keys
-    end
-  end
 
   defmodule State do
     @moduledoc false
@@ -102,12 +45,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.PlaybackState()` message with no further constraints,
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with no further constraints,
   sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
-  @spec await_playback_state(pid()) :: Membrane.RemoteControlled.Pipeline.Message.t()
+  @spec await_playback_state(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_playback_state(pipeline) do
     receive do
       %Message{from: ^pipeline, body: %Message.PlaybackState{}} = message ->
@@ -116,13 +59,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.PlaybackState()` message with the given `state`,
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.PlaybackState()` message with the given `state`,
   sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_playback_state(pid, Membrane.PlaybackState.t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_playback_state(pipeline, playback_state) do
     receive do
       %Message{from: ^pipeline, body: %Message.PlaybackState{state: ^playback_state}} = message ->
@@ -131,12 +74,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.StartOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
   with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
-  @spec await_start_of_stream(pid) :: Membrane.RemoteControlled.Pipeline.Message.t()
+  @spec await_start_of_stream(pid) :: Membrane.RemoteControlled.Message.t()
   def await_start_of_stream(pipeline) do
     receive do
       %Message{from: ^pipeline, body: %Message.StartOfStream{}} = message ->
@@ -145,13 +88,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.StartOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_start_of_stream(pid(), Membrane.Element.name_t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_start_of_stream(pipeline, element) do
     receive do
       %Message{from: ^pipeline, body: %Message.StartOfStream{element: ^element}} = message ->
@@ -160,13 +103,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.StartOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.StartOfStream()` message
   concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_start_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_start_of_stream(pipeline, element, pad) do
     receive do
       %Message{from: ^pipeline, body: %Message.StartOfStream{element: ^element, pad: ^pad}} =
@@ -176,12 +119,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.EndOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
   with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
-  @spec await_end_of_stream(pid()) :: Membrane.RemoteControlled.Pipeline.Message.t()
+  @spec await_end_of_stream(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_end_of_stream(pipeline) do
     receive do
       %Message{from: ^pipeline, body: %Message.EndOfStream{}} = message ->
@@ -190,13 +133,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.EndOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_end_of_stream(pid(), Membrane.Element.name_t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_end_of_stream(pipeline, element) do
     receive do
       %Message{from: ^pipeline, body: %Message.EndOfStream{element: ^element}} = message ->
@@ -205,13 +148,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.EndOfStream()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.EndOfStream()` message
   concerning the given `element` and the `pad`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_end_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_end_of_stream(pipeline, element, pad) do
     receive do
       %Message{from: ^pipeline, body: %Message.EndOfStream{element: ^element, pad: ^pad}} =
@@ -221,12 +164,12 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.Notification()`
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()`
   message with no further constraints, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
-  @spec await_notification(pid()) :: Membrane.RemoteControlled.Pipeline.Message.t()
+  @spec await_notification(pid()) :: Membrane.RemoteControlled.Message.t()
   def await_notification(pipeline) do
     receive do
       %Message{from: ^pipeline, body: %Message.Notification{}} = message ->
@@ -235,13 +178,13 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for the first `Membrane.RemoteControlled.Pipeline.Message()` wrapping the `Membrane.RemoteControlled.Pipeline.Message.Notification()` message
+  Awaits for the first `Membrane.RemoteControlled.Message()` wrapping the `Membrane.RemoteControlled.Message.Notification()` message
   concerning the given `element`, sent by the process with `pipeline` pid.
   It is required to firstly use the `Membrane.RemoteControlled.Pipeline.subscribe/2` to subscribe for given message before awaiting
   for that message.
   """
   @spec await_notification(pid(), Membrane.Notification.t()) ::
-          Membrane.RemoteControlled.Pipeline.Message.t()
+          Membrane.RemoteControlled.Message.t()
   def await_notification(pipeline, element) do
     receive do
       %Message{from: ^pipeline, body: %Message.Notification{element: ^element}} = message ->
@@ -250,7 +193,7 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for a `Membrane.RemoteControlled.Pipeline.Message()` wrapping the given `message_type`, with some fields specified according to the `keywords` list, sent by the
+  Awaits for a `Membrane.RemoteControlled.Message()` wrapping the given `message_type`, with some fields specified according to the `keywords` list, sent by the
   process with the `pipeline` pid.
 
   Arguments:
@@ -274,7 +217,7 @@ defmodule Membrane.RemoteControlled.Pipeline do
       receive do
         %Message{
           from: ^unquote(pipeline),
-          body: %Membrane.RemoteControlled.Pipeline.Message.unquote(message_type){
+          body: %Membrane.RemoteControlled.Message.unquote(message_type){
             unquote_splicing(Macro.expand(keywords, __ENV__))
           }
         } = msg ->
@@ -284,7 +227,7 @@ defmodule Membrane.RemoteControlled.Pipeline do
   end
 
   @doc """
-  Awaits for a `Membrane.RemoteControlled.Pipeline.Message()`, which `:body` field matches the given `message_pattern`, sent by the
+  Awaits for a `Membrane.RemoteControlled.Message()`, which `:body` field matches the given `message_pattern`, sent by the
   process with the `pipeline` pid.
 
   Arguments:

--- a/test/membrane/remote_controlled/pipeline_test.exs
+++ b/test/membrane/remote_controlled/pipeline_test.exs
@@ -1,16 +1,15 @@
 defmodule Membrane.RemoteControlled.PipelineTest do
   use ExUnit.Case
-
   alias Membrane.RemoteControlled.Pipeline
   alias Membrane.ParentSpec
   alias Membrane.RemoteControlled.Pipeline.Message
-
   require Membrane.RemoteControlled.Pipeline
 
   defmodule Filter do
     use Membrane.Filter
-    def_output_pad :output, caps: :any, availability: :always
+    alias Membrane.Buffer
 
+    def_output_pad :output, caps: :any, availability: :always
     def_input_pad :input, demand_unit: :buffers, caps: :any, availability: :always
 
     @impl true
@@ -24,7 +23,7 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       notification_actions =
         if rem(state.buffer_count, 3) == 0 do
-          [{:notify, :test_notification}]
+          [{:notify, %Buffer{payload: "test"}}]
         else
           []
         end
@@ -58,36 +57,62 @@ defmodule Membrane.RemoteControlled.PipelineTest do
     setup :setup_pipeline
 
     test "testing process should receive all subscribed events", %{pipeline: pipeline} do
+      # SETUP
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: :prepared})
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: :playing})
-      Pipeline.subscribe(pipeline, %Message.Notification{element: :b, data: :test_notification})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: :b, data: %Membrane.Buffer{}})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: :b, pad: :input})
 
+      # RUN
       Pipeline.play(pipeline)
 
+      # TEST
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :prepared}}
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :playing}}
-      assert_receive %Message{from: ^pipeline, body: %Message.Notification{element: :b, data: :test_notification}}
-      assert_receive %Message{from: ^pipeline, body: %Message.StartOfStream{element: :b, pad: :input}}
-      refute_receive  %Message{from: ^pipeline, body: %Message.PlaybackState{state: :terminating}}
-      refute_receive  %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
 
+      assert_receive %Message{
+        from: ^pipeline,
+        body: %Message.Notification{element: :b, data: %Membrane.Buffer{payload: "test"}}
+      }
+
+      assert_receive %Message{
+        from: ^pipeline,
+        body: %Message.StartOfStream{element: :b, pad: :input}
+      }
+
+      refute_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :terminating}}
+      refute_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
+
+      # STOP
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
 
     test "should allow to use wildcards in subscription pattern", %{pipeline: pipeline} do
+      # SETUP
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
       Pipeline.subscribe(pipeline, %Message.EndOfStream{})
 
+      # RUN
       Pipeline.play(pipeline)
 
+      # TEST
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :prepared}}
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :playing}}
-      assert_receive %Message{from: ^pipeline, body: %Message.EndOfStream{element: :b, pad: :input}}
-      assert_receive %Message{from: ^pipeline, body: %Message.EndOfStream{element: :c, pad: :input}}
 
+      assert_receive %Message{
+        from: ^pipeline,
+        body: %Message.EndOfStream{element: :b, pad: :input}
+      }
+
+      assert_receive %Message{
+        from: ^pipeline,
+        body: %Message.EndOfStream{element: :c, pad: :input}
+      }
+
+      # STOP
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
 
+      # TEST
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
 
       # assert_receive {:playback_state, :terminating} TODO: figure out why terminating is not delivered
@@ -96,53 +121,133 @@ defmodule Membrane.RemoteControlled.PipelineTest do
     end
   end
 
-  describe "Membrane.RemoteControlled.Pipeline" do
+  describe "Membrane.RemoteControlled.Pipeline await_* functions" do
     setup :setup_pipeline
 
-    test "should await for requested messages with await functions", %{pipeline: pipeline} do
-
+    test "should await for requested messages", %{pipeline: pipeline} do
+      # SETUP
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
       Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
 
-
+      # RUN
       Pipeline.play(pipeline)
 
+      # TEST
       Pipeline.await_playback_state(pipeline, :playing)
       Pipeline.await_start_of_stream(pipeline, :c)
       Pipeline.await_notification(pipeline, :b)
 
+      # STOP
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
+  end
 
+  describe "Membrane.RemoteControlled.Pipeline await_generic/3 macro" do
+    setup :setup_pipeline
 
-    test "should await for requested messages with generic await macro", %{pipeline: pipeline} do
-
+    test "should await for requested messages", %{pipeline: pipeline} do
+      # SETUP
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
       Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
 
+      # RUN
       Pipeline.play(pipeline)
 
-      Pipeline.await_generic(^pipeline, PlaybackState, state: :playing)
-      Pipeline.await_generic(^pipeline, StartOfStream, element: :c)
-      Pipeline.await_generic(^pipeline, Notification, element: :b)
+      # TEST
+      Pipeline.await_generic(pipeline, PlaybackState, state: :playing)
+      Pipeline.await_generic(pipeline, StartOfStream, element: :c, pad: :input)
 
+      Pipeline.await_generic(pipeline, Notification,
+        element: :b,
+        data: %Membrane.Buffer{payload: "test"}
+      )
+
+      # STOP
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
 
-    test "should await for requested messages with generic await macro2", %{pipeline: pipeline} do
-
+    test "should await for requested messages with parts of message body not being specified", %{
+      pipeline: pipeline
+    } do
+      # SETUP
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
       Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
 
+      # RUN
       Pipeline.play(pipeline)
 
-      Pipeline.await_generic2(^pipeline, %Message.PlaybackState{state: :playing})
-      Pipeline.await_generic2(^pipeline, %Message.StartOfStream{element: :c})
-      Pipeline.await_generic2(^pipeline, %Message.Notification{element: :b})
+      # TEST
+      Pipeline.await_generic(pipeline, StartOfStream, element: :c)
+      msg = Pipeline.await_generic(pipeline, Notification, element: :b)
 
+      assert msg == %Message{
+               from: pipeline,
+               body: %Message.Notification{element: :b, data: %Membrane.Buffer{payload: "test"}}
+             }
+
+      # STOP
+      Pipeline.stop_and_terminate(pipeline, blocking?: true)
+    end
+
+    test "should await for requested messages with pinned variables as message body parts", %{
+      pipeline: pipeline
+    } do
+      alias Membrane.Buffer, as: MemBuff
+
+      # SETUP
+      Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
+      Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+      state = :playing
+      test_payload = "test"
+
+      # START
+      Pipeline.play(pipeline)
+
+      # TEST
+      Pipeline.await_generic(pipeline, PlaybackState, state: state)
+      Pipeline.await_generic(pipeline, StartOfStream, element: :c)
+
+      Pipeline.await_generic(pipeline, Notification,
+        element: :b,
+        data: %MemBuff{payload: test_payload}
+      )
+
+      # STOP
+      Pipeline.stop_and_terminate(pipeline, blocking?: true)
+    end
+  end
+
+  describe "Membrane.RemoteControlled.Pipeline await_generic_with_alternative_syntax/2 macro" do
+    setup :setup_pipeline
+
+    test "should await for requested messages", %{pipeline: pipeline} do
+      # SETUP
+      state = :playing
+      test_payload = "test"
+      Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
+      Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+
+      # RUN
+      Pipeline.play(pipeline)
+
+      # TEST
+      Pipeline.await_generic_with_alternative_syntax(pipeline, %Message.PlaybackState{
+        state: state
+      })
+
+      Pipeline.await_generic_with_alternative_syntax(pipeline, %Message.StartOfStream{element: :c})
+
+      Pipeline.await_generic_with_alternative_syntax(pipeline, %Message.Notification{
+        element: :b,
+        data: %Membrane.Buffer{payload: test_payload}
+      })
+
+      # STOP
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
   end

--- a/test/membrane/remote_controlled/pipeline_test.exs
+++ b/test/membrane/remote_controlled/pipeline_test.exs
@@ -65,12 +65,12 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       Pipeline.play(pipeline)
 
-      assert_receive  %Message.PlaybackState{from: ^pipeline, state: :prepared}
-      assert_receive  %Message.PlaybackState{from: ^pipeline, state: :playing}
-      assert_receive %Message.Notification{from: ^pipeline, element: :b, data: :test_notification}
-      assert_receive %Message.StartOfStream{from: ^pipeline, element: :b, pad: :input}
-      refute_receive %Message.PlaybackState{from: ^pipeline, state: :terminating}
-      refute_receive %Message.PlaybackState{from: ^pipeline, state: :stopped}
+      assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :prepared}}
+      assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :playing}}
+      assert_receive %Message{from: ^pipeline, body: %Message.Notification{element: :b, data: :test_notification}}
+      assert_receive %Message{from: ^pipeline, body: %Message.StartOfStream{element: :b, pad: :input}}
+      refute_receive  %Message{from: ^pipeline, body: %Message.PlaybackState{state: :terminating}}
+      refute_receive  %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
 
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
@@ -81,18 +81,18 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       Pipeline.play(pipeline)
 
-      assert_receive  %Message.PlaybackState{from: ^pipeline, state: :prepared}
-      assert_receive  %Message.PlaybackState{from: ^pipeline, state: :playing}
-      assert_receive %Message.EndOfStream{from: ^pipeline, element: :b, pad: :input}
-      assert_receive %Message.EndOfStream{from: ^pipeline, element: :c, pad: :input}
+      assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :prepared}}
+      assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :playing}}
+      assert_receive %Message{from: ^pipeline, body: %Message.EndOfStream{element: :b, pad: :input}}
+      assert_receive %Message{from: ^pipeline, body: %Message.EndOfStream{element: :c, pad: :input}}
 
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
 
-      assert_receive %Message.PlaybackState{from: ^pipeline, state: :stopped}
+      assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
 
       # assert_receive {:playback_state, :terminating} TODO: figure out why terminating is not delivered
-      refute_receive %Message.Notification{from: ^pipeline}
-      refute_receive %Message.StartOfStream{from: ^pipeline, element: _, pad: _}
+      refute_receive %Message{from: ^pipeline, body: %Message.Notification{}}
+      refute_receive %Message{from: ^pipeline, body: %Message.StartOfStream{element: _, pad: _}}
     end
   end
 
@@ -124,9 +124,9 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       Pipeline.play(pipeline)
 
-      Pipeline.await_generic(PlaybackState, from: ^pipeline, state: :playing)
-      Pipeline.await_generic(StartOfStream, from: ^pipeline, element: :c)
-      Pipeline.await_generic(Notification, from: ^pipeline, element: :b)
+      Pipeline.await_generic(^pipeline, PlaybackState, state: :playing)
+      Pipeline.await_generic(^pipeline, StartOfStream, element: :c)
+      Pipeline.await_generic(^pipeline, Notification, element: :b)
 
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end
@@ -139,9 +139,9 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       Pipeline.play(pipeline)
 
-      Pipeline.await_generic2(%Message.PlaybackState{from: ^pipeline, state: :playing})
-      Pipeline.await_generic2(%Message.StartOfStream{from: ^pipeline, element: :c})
-      Pipeline.await_generic2(%Message.Notification{from: ^pipeline, element: :b})
+      Pipeline.await_generic2(^pipeline, %Message.PlaybackState{state: :playing})
+      Pipeline.await_generic2(^pipeline, %Message.StartOfStream{element: :c})
+      Pipeline.await_generic2(^pipeline, %Message.Notification{element: :b})
 
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end

--- a/test/membrane/remote_controlled/pipeline_test.exs
+++ b/test/membrane/remote_controlled/pipeline_test.exs
@@ -99,18 +99,49 @@ defmodule Membrane.RemoteControlled.PipelineTest do
   describe "Membrane.RemoteControlled.Pipeline" do
     setup :setup_pipeline
 
-    test "example usage test", %{pipeline: pipeline} do
+    test "should await for requested messages with await functions", %{pipeline: pipeline} do
+
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
-      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+
 
       Pipeline.play(pipeline)
 
-      #Pipeline.await(pipeline, {:playback_state, element, %Buffer{payload: _}})
       Pipeline.await_playback_state(pipeline, :playing)
-      Pipeline.await_start_of_stream(pipeline, :b)
-      msg = Pipeline.await_notification(pipeline, :b)
-      IO.inspect(msg)
+      Pipeline.await_start_of_stream(pipeline, :c)
+      Pipeline.await_notification(pipeline, :b)
+
+      Pipeline.stop_and_terminate(pipeline, blocking?: true)
+    end
+
+
+    test "should await for requested messages with generic await macro", %{pipeline: pipeline} do
+
+      Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
+      Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+
+      Pipeline.play(pipeline)
+
+      Pipeline.await_generic(PlaybackState, from: ^pipeline, state: :playing)
+      Pipeline.await_generic(StartOfStream, from: ^pipeline, element: :c)
+      Pipeline.await_generic(Notification, from: ^pipeline, element: :b)
+
+      Pipeline.stop_and_terminate(pipeline, blocking?: true)
+    end
+
+    test "should await for requested messages with generic await macro2", %{pipeline: pipeline} do
+
+      Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
+      Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
+      Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+
+      Pipeline.play(pipeline)
+
+      Pipeline.await_generic2(%Message.PlaybackState{from: ^pipeline, state: :playing})
+      Pipeline.await_generic2(%Message.StartOfStream{from: ^pipeline, element: :c})
+      Pipeline.await_generic2(%Message.Notification{from: ^pipeline, element: :b})
 
       Pipeline.stop_and_terminate(pipeline, blocking?: true)
     end

--- a/test/membrane/remote_controlled/pipeline_test.exs
+++ b/test/membrane/remote_controlled/pipeline_test.exs
@@ -1,8 +1,8 @@
 defmodule Membrane.RemoteControlled.PipelineTest do
   use ExUnit.Case
   alias Membrane.RemoteControlled.Pipeline
+  alias Membrane.RemoteControlled.Message
   alias Membrane.ParentSpec
-  alias Membrane.RemoteControlled.Pipeline.Message
   require Membrane.RemoteControlled.Pipeline
 
   defmodule Filter do
@@ -58,6 +58,7 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
     test "testing process should receive all subscribed events", %{pipeline: pipeline} do
       # SETUP
+
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: :prepared})
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: :playing})
       Pipeline.subscribe(pipeline, %Message.Notification{element: :b, data: %Membrane.Buffer{}})

--- a/test/membrane/remote_controlled/pipeline_test.exs
+++ b/test/membrane/remote_controlled/pipeline_test.exs
@@ -80,7 +80,7 @@ defmodule Membrane.RemoteControlled.PipelineTest do
         body: %Message.StartOfStream{element: :b, pad: :input}
       }
 
-      refute_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :terminating}}
+      refute_receive %Message{from: ^pipeline, body: %Message.Terminated{}}
       refute_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
 
       # STOP
@@ -114,8 +114,7 @@ defmodule Membrane.RemoteControlled.PipelineTest do
 
       # TEST
       assert_receive %Message{from: ^pipeline, body: %Message.PlaybackState{state: :stopped}}
-
-      # assert_receive {:playback_state, :terminating} TODO: figure out why terminating is not delivered
+      refute_receive %Message{from: ^pipeline, body: %Message.Terminated{}}
       refute_receive %Message{from: ^pipeline, body: %Message.Notification{}}
       refute_receive %Message{from: ^pipeline, body: %Message.StartOfStream{element: _, pad: _}}
     end
@@ -129,6 +128,7 @@ defmodule Membrane.RemoteControlled.PipelineTest do
       Pipeline.subscribe(pipeline, %Message.PlaybackState{state: _})
       Pipeline.subscribe(pipeline, %Message.StartOfStream{element: _, pad: _})
       Pipeline.subscribe(pipeline, %Message.Notification{element: _, data: _})
+      Pipeline.subscribe(pipeline, %Message.Terminated{})
 
       # RUN
       Pipeline.play(pipeline)


### PR DESCRIPTION
Solves the problems with warnings and illegible pattern syntax in the await macros.
Provides three alternative syntaxes for the patterns. 
Defines the message structure.
Problem with  :terminating message not being delivered is a result of handle_stopped_to_terminating/2 callback not being called, probably due to this implementation: https://github.com/membraneframework/membrane_core/blob/f7ff09f929d26c455cc2b3d117c8ddf428f162d3/lib/membrane/core/playback_handler.ex#L82

As I can see, there are no tests for the handle_stopped_to_terminating/2 callback, and its invocation in the PlaybackHandler has been removed ~2 years ago, in https://github.com/membraneframework/membrane_core/commit/5867a6ef22ce67703a9443dbe1f85aff98ad8741 
