### PR TITLE
Temporairly disable error on unlinking static pads due to possible RC

### DIFF
--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -164,8 +164,12 @@ defmodule Membrane.Core.Element.PadController do
       {:ok, state}
     else
       {:error, {:invalid_playback_state, pad_ref}} ->
-        raise LinkError,
-              "Tried to unlink static pad #{pad_ref} while #{inspect(state.name)} was in or was transitioning to playback state #{state.playback.target_state}."
+        # TODO: after playback states refactor, make it raise
+        Membrane.Logger.debug(
+          "Tried to unlink static pad #{pad_ref} while #{inspect(state.name)} was in or was transitioning to playback state #{state.playback.target_state}."
+        )
+
+        {:ok, state}
 
       {:error, {:unknown_pad, _pad_ref}} ->
         {:ok, state}

--- a/test/membrane/integration/linking_test.exs
+++ b/test/membrane/integration/linking_test.exs
@@ -166,7 +166,8 @@ defmodule Membrane.Integration.LinkingTest do
       # Source has a static pad so it should crash when this pad is being unlinked while being
       # in playing state. If source crashes with proper error it means that :handle_unlink message
       # has been properly forwarded by a bin.
-      assert_receive(
+      # TODO: after playback states refactor, change to assert_receive
+      refute_receive(
         {:DOWN, ^source_ref, :process, ^source_pid,
          {%Membrane.LinkError{
             message:


### PR DESCRIPTION
https://membraneframework.atlassian.net/browse/MC-49?atlOrigin=eyJpIjoiMmFjOTQwYmEzMzdkNGNiMGI3MmQ0YjJhYTRkZjgxYTgiLCJwIjoiaiJ9