### PR TITLE
Better Testing.Pipeline.execute_actions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,8 @@ defmodule Membrane.Mixfile do
         Membrane.Caps,
         Membrane.Event,
         Membrane.EventProtocol,
-        Membrane.Testing
+        Membrane.Testing,
+        Membrane.RemoteControlled
       ],
       groups_for_modules: [
         Pipeline: [~r/^Membrane\.Pipeline($|\.)/, ~r/^Membrane\.(CrashGroup)($|\.)/],


### PR DESCRIPTION
Improve the documentation. Remove misleading information about Testing.Pipeline options from the documentation. Make sure execute_action no more calls handle_other in the custom module.