### PR TITLE
Change `debug_verbose` to `debug` in `Element.LifecycleController.handle_playback_state_changed/3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Refine communication between parent and its children [#270](https://github.com/membraneframework/membrane_core/issues/270)
  * Add `handle_call/3` callback in the pipeline, as well as a `:reply` and `:reply_to` actions. Rename `handle_other/3` callback into `handle_info/3` [#334](https://github.com/membraneframework/membrane_core/issues/334)
  * Add `Membrane.FilterAggregator` that allows to run multiple filters sequentially within one process. [#355](https://github.com/membraneframework/membrane_core/pull/355)
+ * Log info about element's playback state change as debug, not as debug_verbose. [#430](https://github.com/membraneframework/membrane_core/pull/430)
 
 ## 0.10.0
  * Remove all deprecated stuff [#399](https://github.com/membraneframework/membrane_core/pull/399)

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -156,7 +156,7 @@ defmodule Membrane.Core.Element.LifecycleController do
 
   @impl PlaybackHandler
   def handle_playback_state_changed(old, new, state) do
-    Membrane.Logger.debug_verbose("Playback state changed from #{old} to #{new}")
+    Membrane.Logger.debug("Playback state changed from #{old} to #{new}")
 
     state = PlaybackBuffer.eval(state)
 


### PR DESCRIPTION
Here 
https://github.com/membraneframework/membrane_core/blob/4bbe68920bb2e55b84dde3118e862a753ab5e439/lib/membrane/core/parent/lifecycle_controller.ex#L67

we log info about playback state change as debug so I think that in `Element.LifecycleController` we should do the same.