### PR TITLE
Set `trap_exit` to `true` before killing Element.

### DIFF
--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -161,7 +161,7 @@ defmodule Membrane.Core.Element.LifecycleController do
     state = PlaybackBuffer.eval(state)
 
     if new == :terminating do
-      Process.flag(:trap_exit, false)
+      Process.flag(:trap_exit, true)
       Process.exit(self(), :normal)
     end
 

--- a/lib/membrane/core/parent/child_life_controller.ex
+++ b/lib/membrane/core/parent/child_life_controller.ex
@@ -242,7 +242,7 @@ defmodule Membrane.Core.Parent.ChildLifeController do
     Terminating.
     """)
 
-    Process.flag(:trap_exit, false)
+    Process.flag(:trap_exit, true)
     Process.exit(self(), {:shutdown, :child_crash})
   end
 

--- a/lib/membrane/core/parent/lifecycle_controller.ex
+++ b/lib/membrane/core/parent/lifecycle_controller.ex
@@ -67,7 +67,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
     Membrane.Logger.debug("Playback state changed from #{old} to #{new}")
 
     if new == :terminating do
-      Process.flag(:trap_exit, false)
+      Process.flag(:trap_exit, true)
       Process.exit(self(), :normal)
     end
 


### PR DESCRIPTION
This should guarantee calling `c:handle_shutdown/2`.

The current `Process.flag(:trap_exit, false)` was introduced in https://github.com/membraneframework/membrane_core/pull/418. Before #418 we were returning `{:stop, ...}` tuple which cause calling `c:terminate/2` which then calls `c:handle_shutdown/2`. 