### PR TITLE
only configure junit in test env

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,5 @@
 import Config
 
-config :junit_formatter,
-  include_filename?: true
+if Mix.env() == :test do
+  config :junit_formatter, include_filename?: true
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 import Config
 
-if Mix.env() == :test do
+if config_env() == :test do
   config :junit_formatter, include_filename?: true
 end


### PR DESCRIPTION
Without this, the following warning is printed:
```
You have configured application :junit_formatter in your configuration file,
but the application is not available.

This usually means one of:

  1. You have not added the application as a dependency in a mix.exs file.

  2. You are configuring an application that does not really exist.

Please ensure :junit_formatter exists or remove the configuration.
```