### PR TITLE
Add ability to spawn anonymous children

### DIFF
--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -329,16 +329,49 @@ defmodule Membrane.ChildrenSpec do
   end
 
   @doc """
-  Used to spawn an unlinked child or to spawn a child at the beggining of
-  a link specification.
+  Used to spawn an anonymous child at the beggining of the link.
+  """
+  @spec child(child_definition_t()) :: structure_builder_t()
+  def child(child_definition) do
+    child_name = {:anonymous_child, make_ref()}
+    do_child(child_name, child_definition, [])
+  end
+
+  @doc """
+  Used to spawn a child at the beggining of the link.
+  """
+  @spec child(Child.name_t() | child_definition_t(), child_definition_t() | child_options_t) ::
+          Membrane.ChildrenSpec.StructureBuilder.t()
+  def child(child_name, child_definition) when is_child_name?(child_name) do
+    do_child(child_name, child_definition, [])
+  end
+
+  def child(child_definition, opts) do
+    child_name = {:anonymous_child, make_ref()}
+    do_child(child_name, child_definition, opts)
+  end
+
+  @doc """
+  Used to spawn an unlinked child, anonymous child in the middle of the link
+  or to spawn a child at the beggining of a link.
 
   See the _structure_ section of the moduledoc for more information.
   """
-  @spec child(Child.name_t(), child_definition_t(), child_options_t()) :: structure_builder_t()
-  def child(child_name, child_definition, opts \\ [])
+  @spec child(
+          StructureBuilder.t() | Child.name_t(),
+          Child.name_t() | child_definition_t(),
+          child_options_t()
+        ) :: structure_builder_t()
+  def child(first_arg, second_arg, third_arg)
 
-  def child(%StructureBuilder{} = structure_builder, child_name, child_definition) do
+  def child(%StructureBuilder{} = structure_builder, child_name, child_definition)
+      when is_child_name?(child_name) do
     do_child(structure_builder, child_name, child_definition, [])
+  end
+
+  def child(%StructureBuilder{} = structure_builder, child_definition, options) do
+    child_name = {:anonymous_child, make_ref()}
+    do_child(structure_builder, child_name, child_definition, options)
   end
 
   def child(child_name, child_definition, options) when is_child_name?(child_name) do

--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -614,8 +614,8 @@ defmodule Membrane.ChildrenSpec do
   defp ensure_is_child_definition(child_definition) do
     module = get_module(child_definition)
 
-    if not is_atom(module) or
-         (not Membrane.Element.element?(module) and not Membrane.Bin.bin?(module)) do
+    unless is_atom(module) and
+         (Membrane.Element.element?(module) or Membrane.Bin.bin?(module)) do
       raise ParentError, not_child: child_definition
     end
   end

--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -611,7 +611,7 @@ defmodule Membrane.ChildrenSpec do
   defp get_module(%module{}), do: module
   defp get_module(module), do: module
 
-  defp ensure_is_child_definition(child_definition) do
+  defp ensure_is_child_definition!(child_definition) do
     module = get_module(child_definition)
 
     unless is_atom(module) and

--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -341,7 +341,7 @@ defmodule Membrane.ChildrenSpec do
   Used to spawn a child at the beggining of the link.
   """
   @spec child(Child.name_t() | child_definition_t(), child_definition_t() | child_options_t) ::
-          Membrane.ChildrenSpec.StructureBuilder.t()
+          structure_builder_t()
   def child(child_name, child_definition) when is_child_name?(child_name) do
     do_child(child_name, child_definition, [])
   end
@@ -358,7 +358,7 @@ defmodule Membrane.ChildrenSpec do
   See the _structure_ section of the moduledoc for more information.
   """
   @spec child(
-          StructureBuilder.t() | Child.name_t(),
+          structure_builder_t | Child.name_t(),
           Child.name_t() | child_definition_t(),
           child_options_t()
         ) :: structure_builder_t()

--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -608,17 +608,15 @@ defmodule Membrane.ChildrenSpec do
     raise ParentError, "Invalid link specification: invalid pad name: #{inspect(pad)}"
   end
 
-  defp get_module(child_definition) when is_struct(child_definition) do
-    %module{} = child_definition
-    module
-  end
-
+  defp get_module(%module{}), do: module
   defp get_module(module), do: module
 
   defp ensure_is_child_definition(child_definition) do
-    if not (is_struct(child_definition) or
-              (is_atom(child_definition) and Code.ensure_loaded?(child_definition))) do
-      raise ParentError, not_module_nor_struct: child_definition
+    module = get_module(child_definition)
+
+    if not is_atom(module) or
+         (not Membrane.Element.element?(module) and not Membrane.Bin.bin?(module)) do
+      raise ParentError, not_child: child_definition
     end
   end
 end

--- a/lib/membrane/children_spec.ex
+++ b/lib/membrane/children_spec.ex
@@ -330,6 +330,8 @@ defmodule Membrane.ChildrenSpec do
 
   @doc """
   Used to spawn an anonymous child at the beggining of the link.
+
+  See the _structure_ section of the moduledoc for more information.
   """
   @spec child(child_definition_t()) :: structure_builder_t()
   def child(child_definition) do
@@ -338,12 +340,20 @@ defmodule Membrane.ChildrenSpec do
   end
 
   @doc """
-  Used to spawn a child at the beggining of the link.
+  Used to spawn a child at the beggining of the link
+  or an anynomous child.
+
+  See the _structure_ section of the moduledoc for more information.
   """
   @spec child(Child.name_t() | child_definition_t(), child_definition_t() | child_options_t) ::
           structure_builder_t()
   def child(child_name, child_definition) when is_child_name?(child_name) do
     do_child(child_name, child_definition, [])
+  end
+
+  def child(%StructureBuilder{} = structure_builder, child_definition) do
+    child_name = {:anonymous_child, make_ref()}
+    do_child(structure_builder, child_name, child_definition, [])
   end
 
   def child(child_definition, opts) do

--- a/lib/membrane/exceptions.ex
+++ b/lib/membrane/exceptions.ex
@@ -22,7 +22,7 @@ defmodule Membrane.ParentError do
     %__MODULE__{message: msg}
   end
 
-  def exception(not_module_nor_struct: child_definition) do
+  def exception(not_child: child_definition) do
     msg = "Child definition: #{inspect(child_definition)} is not a module nor a struct."
     %__MODULE__{message: msg}
   end

--- a/lib/membrane/exceptions.ex
+++ b/lib/membrane/exceptions.ex
@@ -21,11 +21,6 @@ defmodule Membrane.ParentError do
 
     %__MODULE__{message: msg}
   end
-
-  def exception(not_child: child_definition) do
-    msg = "Child definition: #{inspect(child_definition)} is not a module nor a struct."
-    %__MODULE__{message: msg}
-  end
 end
 
 defmodule Membrane.UnknownChildError do

--- a/lib/membrane/exceptions.ex
+++ b/lib/membrane/exceptions.ex
@@ -21,6 +21,11 @@ defmodule Membrane.ParentError do
 
     %__MODULE__{message: msg}
   end
+
+  def exception(not_module_nor_struct: child_definition) do
+    msg = "Child definition: #{inspect(child_definition)} is not a module nor a struct."
+    %__MODULE__{message: msg}
+  end
 end
 
 defmodule Membrane.UnknownChildError do

--- a/test/membrane/core/parent/structure_parser_test.exs
+++ b/test/membrane/core/parent/structure_parser_test.exs
@@ -4,6 +4,10 @@ defmodule Membrane.Core.Parent.StructureParserTest do
   alias Membrane.Core.Parent.{Link, StructureParser}
   alias Membrane.Core.Parent.Link.Endpoint
 
+  defmodule A do
+    use Membrane.Filter
+  end
+
   test "valid link" do
     import Membrane.ChildrenSpec
     require Membrane.Pad
@@ -195,7 +199,7 @@ defmodule Membrane.Core.Parent.StructureParserTest do
   test "link creating children" do
     import Membrane.ChildrenSpec
 
-    links_spec = [child(:a, A) |> child(:b, B) |> child(:c, C)]
+    links_spec = [child(:a, A) |> child(:b, A) |> child(:c, A)]
     assert {children, links} = StructureParser.parse(links_spec)
 
     assert [
@@ -235,8 +239,8 @@ defmodule Membrane.Core.Parent.StructureParserTest do
 
     assert Enum.sort(children) == [
              {:a, A, %{get_if_exists: false}},
-             {:b, B, %{get_if_exists: false}},
-             {:c, C, %{get_if_exists: false}}
+             {:b, A, %{get_if_exists: false}},
+             {:c, A, %{get_if_exists: false}}
            ]
   end
 end

--- a/test/membrane/integration/child_spawn_test.exs
+++ b/test/membrane/integration/child_spawn_test.exs
@@ -173,4 +173,9 @@ defmodule Membrane.Integration.ChildSpawnTest do
 
     Testing.Pipeline.terminate(pipeline_pid, blocking?: true)
   end
+
+  test "if children can be spawned anonymously" do
+  end
+
+  test "if anonymous children spawned in children groups can be removed with children group id"
 end

--- a/test/membrane/integration/child_spawn_test.exs
+++ b/test/membrane/integration/child_spawn_test.exs
@@ -175,7 +175,11 @@ defmodule Membrane.Integration.ChildSpawnTest do
   end
 
   test "if children can be spawned anonymously" do
-  end
+    pipeline_pid = Testing.Pipeline.start_supervised!()
+    spec = child(%Testing.Source{output: [1, 2, 3]}) |> child(Testing.Sink)
+    Testing.Pipeline.execute_actions(pipeline_pid, spec: spec)
+    assert_pipeline_play(pipeline_pid)
 
-  test "if anonymous children spawned in children groups can be removed with children group id"
+    Testing.Pipeline.terminate(pipeline_pid, blocking?: true)
+  end
 end

--- a/test/membrane/testing/pipeline_test.exs
+++ b/test/membrane/testing/pipeline_test.exs
@@ -4,6 +4,10 @@ defmodule Membrane.Testing.PipelineTest do
   alias Membrane.ChildrenSpec
   alias Membrane.Testing.Pipeline
 
+  defmodule Elem do
+    use Membrane.Filter
+  end
+
   defmodule MockPipeline do
     use Membrane.Pipeline
 
@@ -50,6 +54,7 @@ defmodule Membrane.Testing.PipelineTest do
   describe "When initializing Testing Pipeline" do
     test "uses prepared links if they were provided" do
       import ChildrenSpec
+
       links = [child(:elem, Elem) |> child(:elem2, Elem)]
       options = [module: :default, structure: links, test_process: nil]
       assert {[spec: spec, playback: :playing], state} = Pipeline.handle_init(%{}, options)


### PR DESCRIPTION
This PR introduces a mechanism to spawn children without specifying their names.
That feature can be useful especially in tests.