### PR TITLE
Fix pad docs generation

### DIFF
--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -246,15 +246,23 @@ defmodule Membrane.Core.Child.PadsSpecs do
     config_doc =
       config
       |> Enum.map(&generate_pad_property_doc/1)
-      |> Enum.map_join("\n", fn {k, v} ->
-        "<tr><td>#{k}</td> <td>#{v}</td></tr>"
+      |> Enum.map_join("\n", fn
+        {k, v} ->
+          if String.contains?(v, "\n") do
+            "#{k}:\n#{v}"
+          else
+            "#{k}: | #{v}"
+          end
+
+        nil ->
+          ""
       end)
 
     options_doc =
       if pad_opts != nil do
         quote do
           """
-          #{Bunch.Markdown.indent("Options:")}
+          Pad options:
 
           #{unquote(OptionsSpecs.generate_opts_doc(pad_opts))}
           """
@@ -267,24 +275,34 @@ defmodule Membrane.Core.Child.PadsSpecs do
       """
       ### `#{inspect(unquote(name))}`
 
-      <table>
       #{unquote(config_doc)}
-      </table>
+
       """ <> unquote(options_doc)
     end
+  end
+
+  defp generate_pad_property_doc({:name, _name}) do
+    nil
   end
 
   defp generate_pad_property_doc({:accepted_formats_str, formats}) do
     {
       "Accepted formats",
-      Enum.map_join(formats, &"<p><code>#{&1}</code></p>")
+      Enum.map_join(
+        formats,
+        &"""
+        ```
+        #{&1}
+        ```
+        """
+      )
     }
   end
 
   defp generate_pad_property_doc({property, value}) do
     {
       property |> to_string() |> String.replace("_", " ") |> String.capitalize(),
-      "<code>#{inspect(value)}</code>"
+      "`#{inspect(value)}`"
     }
   end
 end

--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -241,30 +241,25 @@ defmodule Membrane.Core.Child.PadsSpecs do
   end
 
   defp generate_docs_from_pad_specs({name, config}) do
-    {pad_opts, config} = config |> Map.pop(:options)
+    config = config |> Map.delete(:name)
+
+    accepted_formats_doc = """
+    Accepted formats:
+    #{Enum.map_join(config.accepted_formats_str, "\n", &"```\n#{&1}\n```")}
+    """
 
     config_doc =
-      config
-      |> Enum.map(&generate_pad_property_doc/1)
-      |> Enum.map_join("\n", fn
-        {k, v} ->
-          if String.contains?(v, "\n") do
-            "#{k}:\n#{v}"
-          else
-            "#{k}: | #{v}"
-          end
-
-        nil ->
-          ""
-      end)
+      [:direction, :availability, :mode, :demand_mode, :demand_unit]
+      |> Enum.filter(&Map.has_key?(config, &1))
+      |> Enum.map_join("\n", &generate_pad_property_doc(&1, Map.fetch!(config, &1)))
 
     options_doc =
-      if pad_opts != nil do
+      if config.options do
         quote do
           """
           Pad options:
 
-          #{unquote(OptionsSpecs.generate_opts_doc(pad_opts))}
+          #{unquote(OptionsSpecs.generate_opts_doc(config.options))}
           """
         end
       else
@@ -275,34 +270,15 @@ defmodule Membrane.Core.Child.PadsSpecs do
       """
       ### `#{inspect(unquote(name))}`
 
+      #{unquote(accepted_formats_doc)}
       #{unquote(config_doc)}
-
-      """ <> unquote(options_doc)
+      #{unquote(options_doc)}
+      """
     end
   end
 
-  defp generate_pad_property_doc({:name, _name}) do
-    nil
-  end
-
-  defp generate_pad_property_doc({:accepted_formats_str, formats}) do
-    {
-      "Accepted formats",
-      Enum.map_join(
-        formats,
-        &"""
-        ```
-        #{&1}
-        ```
-        """
-      )
-    }
-  end
-
-  defp generate_pad_property_doc({property, value}) do
-    {
-      property |> to_string() |> String.replace("_", " ") |> String.capitalize(),
-      "`#{inspect(value)}`"
-    }
+  defp generate_pad_property_doc(property, value) do
+    property_str = property |> to_string() |> String.replace("_", " ") |> String.capitalize()
+    "#{property_str}: | `#{inspect(value)}`"
   end
 end

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -24,10 +24,10 @@ defmodule Membrane.Core.Element.DemandHandler do
 
   @doc """
   Called when redemand action was returned.
-    * If element is currently supplying demand it means that after finishing supply_demand it will call
+    * If element is currently supplying demand, it means that after finishing `supply_demand` it will call
       `handle_delayed_demands`.
-    * If <span class="x x-first x-last">the </span>element isn't supplying demand at the moment <span class="x x-first x-last">and there's some unsupplied demand on the given </span>
-      <span class="x x-first x-last">output, `</span>handle_demand<span class="x x-first x-last">` is invoked right away, so that the demand can be synchronously supplied.</span>
+    * If element isn't supplying demand at the moment and there's some unsupplied demand on the given
+      output, `handle_demand` is invoked right away, so that the demand can be synchronously supplied.
   """
   @spec handle_redemand(Pad.ref_t(), State.t()) :: State.t()
   def handle_redemand(pad_ref, %State{supplying_demand?: true} = state) do


### PR DESCRIPTION
Generates pad options without injecting HTML, so that ex_doc doesn't throw warnings and it hopefully displays correctly both in web and iex

![image](https://user-images.githubusercontent.com/16493463/205967295-3bad015c-1e8f-461e-b3c5-e74d9fa385fe.png)

<img width="799" alt="image" src="https://user-images.githubusercontent.com/16493463/205967702-60461526-b5e2-4ee3-8ed4-eac5aa5246fe.png">

![image](https://user-images.githubusercontent.com/16493463/205967435-f34a123b-02bb-42bd-87ee-40ff5fb32fd2.png)

<img width="799" alt="image" src="https://user-images.githubusercontent.com/16493463/205967860-61070848-6b02-4539-bba4-3fb7adebbed1.png">
