### PR TITLE
Demand units conversion autodemands bugfix

### DIFF
--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -179,21 +179,24 @@ defmodule Membrane.Core.Child.PadsSpecs do
                 availability: [in: [:always, :on_request], default: :always],
                 accepted_formats_str: [],
                 mode: [in: [:pull, :push], default: :pull],
-                demand_mode: [
-                  in: [:auto, :manual],
-                  default: :manual
-                ],
+                demand_mode:
+                  &if &1.mode == :pull do
+                    [
+                      in: [:auto, :manual],
+                      default: :manual
+                    ]
+                  end,
                 demand_unit:
                   &cond do
-                    component == :bin ->
+                    component == :bin or &1[:demand_mode] != :manual ->
                       nil
 
-                    &1.mode == :pull and &1.demand_mode == :manual and direction == :input ->
+                    direction == :input ->
                       [
                         in: [:buffers, :bytes]
                       ]
 
-                    &1.mode == :pull and &1.demand_mode == :manual and direction == :output ->
+                    direction == :output ->
                       [
                         in: [:buffers, :bytes, nil],
                         default: nil

--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -185,10 +185,12 @@ defmodule Membrane.Core.Child.PadsSpecs do
                 ],
                 demand_unit:
                   &cond do
+                    component == :bin ->
+                      nil
+
                     &1.mode == :pull and &1.demand_mode == :manual and direction == :input ->
                       [
-                        in: [:buffers, :bytes],
-                        default: :buffers
+                        in: [:buffers, :bytes]
                       ]
 
                     &1.mode == :pull and &1.demand_mode == :manual and direction == :output ->

--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -185,14 +185,13 @@ defmodule Membrane.Core.Child.PadsSpecs do
                 ],
                 demand_unit:
                   &cond do
-                    &1.mode == :pull and direction == :input ->
+                    &1.mode == :pull and &1.demand_mode == :manual and direction == :input ->
                       [
                         in: [:buffers, :bytes],
-                        default: :buffers,
-                        required?: &1.demand_mode == :manual
+                        default: :buffers
                       ]
 
-                    &1.mode == :pull and direction == :output ->
+                    &1.mode == :pull and &1.demand_mode == :manual and direction == :output ->
                       [
                         in: [:buffers, :bytes, nil],
                         default: nil

--- a/lib/membrane/core/element/demand_controller.ex
+++ b/lib/membrane/core/element/demand_controller.ex
@@ -36,7 +36,6 @@ defmodule Membrane.Core.Element.DemandController do
 
   defp do_handle_demand(pad_ref, size, %{demand_mode: :auto} = data, state) do
     %{demand: old_demand, associated_pads: associated_pads} = data
-
     state = PadModel.set_data!(state, pad_ref, :demand, old_demand + size)
 
     if old_demand <= 0 do
@@ -86,6 +85,7 @@ defmodule Membrane.Core.Element.DemandController do
 
     %{
       demand: demand,
+      demand_unit: demand_unit,
       toilet: toilet,
       associated_pads: associated_pads,
       auto_demand_size: demand_request_size

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -218,6 +218,7 @@ defmodule Membrane.Core.Element.PadController do
     end
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp resolve_demand_units(info, other_info) do
     output_info = if info.direction == :output, do: info, else: other_info
     input_info = if info.direction == :input, do: info, else: other_info
@@ -232,9 +233,6 @@ defmodule Membrane.Core.Element.PadController do
             input_info[:demand_mode] == :auto ->
           {:buffers, :buffers}
 
-        output_info.mode == :push and input_info[:demand_mode] == :auto ->
-          {nil, :buffers}
-
         output_info[:demand_mode] == :auto and input_info[:demand_mode] == :manual ->
           {input_info.demand_unit, nil}
 
@@ -245,37 +243,12 @@ defmodule Membrane.Core.Element.PadController do
             input_info[:demand_mode] == :manual ->
           {input_info.demand_unit, nil}
 
+        output_info.mode == :push and input_info[:demand_mode] == :auto ->
+          {nil, :buffers}
+
         true ->
           {nil, nil}
       end
-
-    # info.mode != :pull and other_info.mode != :pull -> {nil, nil}
-    # # AUTO
-    # info.demand_mode == :auto and other_info.demand_mode == :auto ->
-    #   {:buffers, :buffers}
-
-    # info.demand_mode == :auto ->
-    #   demand_unit =
-    #     if other_info[:demand_unit] != nil, do: other_info.demand_unit, else: :buffers
-    #   {demand_unit, demand_unit}
-
-    # # MANUAL
-    # info.direction == :output ->
-    #   demand_unit =
-    #     if info[:demand_unit] == nil, do: other_info.demand_unit, else: info.demand_unit
-
-    #   {demand_unit, nil}
-
-    # info.direction == :input ->
-    #   other_demand_unit =
-    #     if other_info[:demand_unit] == nil,
-    #       do: info.demand_unit,
-    #       else: other_info.demand_unit
-
-    #   {nil, other_demand_unit}
-
-    # true ->
-    #   {nil, nil}
 
     {output_info, input_info} =
       if output_demand_unit != nil do

--- a/test/membrane/core/element/pad_controller_test.exs
+++ b/test/membrane/core/element/pad_controller_test.exs
@@ -32,7 +32,12 @@ defmodule Membrane.Core.Element.PadControllerTest do
                @module.handle_link(
                  :output,
                  %{pad_ref: :output, pid: self(), pad_props: %{options: []}, child: :a},
-                 %{pad_ref: :other_input, pid: nil, child: :b},
+                 %{
+                   pad_ref: :other_input,
+                   pid: nil,
+                   child: :b,
+                   pad_props: %{options: [], toilet_capacity: nil, throttling_factor: nil}
+                 },
                  %{
                    initiator: :sibling,
                    other_info: %{direction: :input, mode: :pull, demand_unit: :buffers},

--- a/test/membrane/core/element_test.exs
+++ b/test/membrane/core/element_test.exs
@@ -74,7 +74,8 @@ defmodule Membrane.Core.ElementTest do
             pad_spec: :dynamic_input,
             pad_ref: :dynamic_input,
             pid: self(),
-            child: :other
+            child: :other,
+            pad_props: %{options: [], toilet_capacity: nil, throttling_factor: nil}
           },
           %{
             initiator: :sibling,
@@ -211,11 +212,16 @@ defmodule Membrane.Core.ElementTest do
                    pad_props: %{options: [], toilet_capacity: nil},
                    child: :this
                  },
-                 %{pad_ref: :dynamic_input, pid: pid, child: :other},
+                 %{
+                   pad_ref: :dynamic_input,
+                   pid: pid,
+                   child: :other,
+                   pad_props: %{options: [], toilet_capacity: nil, throttling_factor: nil}
+                 },
                  %{
                    initiator: :sibling,
                    other_info: %{direction: :input, mode: :pull, demand_unit: :buffers},
-                   link_metadata: %{toilet: nil, observability_metadata: %{}},
+                   link_metadata: %{observability_metadata: %{}},
                    stream_format_validation_params: []
                  }
                ]),
@@ -232,7 +238,9 @@ defmodule Membrane.Core.ElementTest do
               mode: :pull,
               name: :output,
               options: nil
-            }, %{toilet: nil}} = reply
+            }, %{toilet: toilet}} = reply
+
+    assert toilet != nil
 
     assert %Membrane.Element.PadData{
              pid: ^pid,

--- a/test/membrane/integration/elements_compatibility_test.exs
+++ b/test/membrane/integration/elements_compatibility_test.exs
@@ -117,6 +117,15 @@ defmodule Membrane.Integration.ElementsCompatibilityTest do
     end
 
     @impl true
+    def handle_playing(ctx, state) do
+      if ctx.pads.output.demand_unit != ctx.pads.output.other_demand_unit do
+        raise "Autodemand demand unit resolved improperly"
+      end
+
+      {[], state}
+    end
+
+    @impl true
     def handle_process(:input, buf, _ctx, state) do
       {[buffer: {:output, buf}], state}
     end
@@ -264,7 +273,7 @@ defmodule Membrane.Integration.ElementsCompatibilityTest do
 
   test "if sink demanding in bytes receives all the data and no more then demanded number of bytes at once when is preceed by  autodemand filter" do
     Enum.each(
-      [PushSource, PullBytesSource, PullBuffersSource],
+      [PullBytesSource],
       &test_sink(&1, PullBytesSink, true)
     )
   end

--- a/test/membrane/integration/linking_test.exs
+++ b/test/membrane/integration/linking_test.exs
@@ -14,11 +14,13 @@ defmodule Membrane.Integration.LinkingTest do
 
     def_input_pad :input,
       availability: :on_request,
-      accepted_format: _any
+      accepted_format: _any,
+      demand_unit: :buffers
 
     def_output_pad :output,
       availability: :on_request,
-      accepted_format: _any
+      accepted_format: _any,
+      demand_unit: :buffers
 
     @impl true
     def handle_demand(_pad, _size, _unit, _ctx, state) do

--- a/test/membrane/integration/linking_test.exs
+++ b/test/membrane/integration/linking_test.exs
@@ -40,7 +40,6 @@ defmodule Membrane.Integration.LinkingTest do
                 remove_child_on_unlink: [spec: boolean(), default: true]
 
     def_output_pad :output,
-      demand_unit: :buffers,
       accepted_format: _any,
       availability: :on_request
 
@@ -408,8 +407,7 @@ defmodule Membrane.Integration.LinkingTest do
 
       def_input_pad :input,
         availability: :on_request,
-        accepted_format: _any,
-        demand_unit: :buffers
+        accepted_format: _any
     end
 
     pipeline =

--- a/test/membrane/integration/sync_test.exs
+++ b/test/membrane/integration/sync_test.exs
@@ -87,8 +87,8 @@ defmodule Membrane.Integration.SyncTest do
   defmodule SimpleBin do
     use Membrane.Bin
 
-    def_input_pad :input, demand_unit: :buffers, accepted_format: _any
-    def_output_pad :output, accepted_format: _any, demand_unit: :buffers
+    def_input_pad :input, accepted_format: _any
+    def_output_pad :output, accepted_format: _any
 
     @impl true
     def handle_init(_ctx, _options) do

--- a/test/support/accepted_format_test/inner_source_bin.ex
+++ b/test/support/accepted_format_test/inner_source_bin.ex
@@ -12,7 +12,6 @@ defmodule Membrane.Support.AcceptedFormatTest.InnerSourceBin do
   alias Membrane.Support.AcceptedFormatTest.StreamFormat.{AcceptedByAll, AcceptedByInnerBins}
 
   def_output_pad :output,
-    demand_unit: :buffers,
     accepted_format:
       %StreamFormat{format: format} when format in [AcceptedByAll, AcceptedByInnerBins]
 

--- a/test/support/accepted_format_test/outer_source_bin.ex
+++ b/test/support/accepted_format_test/outer_source_bin.ex
@@ -12,7 +12,6 @@ defmodule Membrane.Support.AcceptedFormatTest.OuterSourceBin do
   alias Membrane.Support.AcceptedFormatTest.StreamFormat.{AcceptedByAll, AcceptedByOuterBins}
 
   def_output_pad :output,
-    demand_unit: :buffers,
     accepted_format:
       %StreamFormat{format: format} when format in [AcceptedByAll, AcceptedByOuterBins]
 

--- a/test/support/bin/test_bins.ex
+++ b/test/support/bin/test_bins.ex
@@ -71,9 +71,9 @@ defmodule Membrane.Support.Bin.TestBins do
     def_options filter1: [spec: module()],
                 filter2: [spec: module()]
 
-    def_input_pad :input, accepted_format: _any, demand_unit: :buffers
+    def_input_pad :input, accepted_format: _any
 
-    def_output_pad :output, accepted_format: _any, demand_unit: :buffers
+    def_output_pad :output, accepted_format: _any
 
     @impl true
     def handle_init(_ctx, opts) do
@@ -99,12 +99,11 @@ defmodule Membrane.Support.Bin.TestBins do
     @moduledoc false
     use Membrane.Bin
 
-    def_input_pad :input, demand_unit: :buffers, accepted_format: _any, availability: :on_request
+    def_input_pad :input, accepted_format: _any, availability: :on_request
 
     def_output_pad :output,
       accepted_format: _any,
-      availability: :on_request,
-      demand_unit: :buffers
+      availability: :on_request
 
     @impl true
     def handle_init(_ctx, _opts) do
@@ -142,12 +141,11 @@ defmodule Membrane.Support.Bin.TestBins do
     def_options filter1: [spec: module()],
                 filter2: [spec: module()]
 
-    def_input_pad :input, demand_unit: :buffers, accepted_format: _any, availability: :on_request
+    def_input_pad :input, accepted_format: _any, availability: :on_request
 
     def_output_pad :output,
       accepted_format: _any,
-      availability: :on_request,
-      demand_unit: :buffers
+      availability: :on_request
 
     @impl true
     def handle_init(_ctx, opts) do
@@ -185,7 +183,7 @@ defmodule Membrane.Support.Bin.TestBins do
     def_options filter: [spec: module()],
                 sink: [spec: module()]
 
-    def_input_pad :input, demand_unit: :buffers, accepted_format: _any
+    def_input_pad :input, accepted_format: _any
 
     @impl true
     def handle_init(_ctx, opts) do
@@ -271,9 +269,9 @@ defmodule Membrane.Support.Bin.TestBins do
     @moduledoc false
     use Membrane.Bin
 
-    def_input_pad :input, demand_unit: :buffers, accepted_format: _any
+    def_input_pad :input, accepted_format: _any
 
-    def_output_pad :output, accepted_format: _any, demand_unit: :buffers
+    def_output_pad :output, accepted_format: _any
 
     @impl true
     def handle_init(_ctx, _opts) do


### PR DESCRIPTION
This PR fix a bug within the demands unit conversion that was causing the demand unit not to be converted when used with autodemands