### PR TITLE
Add `timer_interval_t` to `Element.Action.t`

### DIFF
--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -237,6 +237,7 @@ defmodule Membrane.Element.Action do
           | redemand_t
           | forward_t
           | start_timer_t
+          | timer_interval_t
           | stop_timer_t
           | latency_t
           | end_of_stream_t


### PR DESCRIPTION
Was going unnoticed for a long time, bumped into it when updating the realtimer plugin :)