### PR TITLE
remove _t suffix from types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0
  * Introduce `:remove_link` action in pipelines and bins.
  * Add children groups - a mechanism that allows refering to multiple children with a single identifier. 
- * Rename `remove_child_t` action into `remove_children_t` and allow for removing a children group with a single action.
+ * Rename `remove_child` action into `remove_children` and allow for removing a children group with a single action.
  * Add an ability to spawn anonymous children.
  * Replace `Membrane.Time.round_to_<unit_name>` with `Membrane.Time.as_<unit_name>/2` with second argument equal `:round`. Rename `Membrane.Time.round_to_timebase` to `Membrane.Time.divide_by_timebase/2`. [#494](https://github.com/membraneframework/membrane_core/pull/494)
  * Remove `:playback` action. Introduce `:setup` action. [#496](https://github.com/membraneframework/membrane_core/pull/496)
@@ -13,6 +13,7 @@
  * Output pads working in `:pull` mode should have their `demand_unit` specified. If case it's not available, it's assumed that the pad handles demands in both `:bytes` and `:buffers` units.
  * Rename callbacks `handle_process/4` and `handle_write/4` to `handle_buffer/4` in [#506](https://github.com/membraneframework/membrane_core/pull/506)
  * The flow control of the pad is now set with a single `:flow_control` option instead of `:mode` and `:demand_mode` options.
+ * Remove _t suffix from types [#509](https://github.com/membraneframework/membrane_core/pull/509)
 
 ## 0.11.0
  * Separate element_name and pad arguments in handle_element_{start, end}_of_stream signature [#219](https://github.com/membraneframework/membrane_core/issues/219)

--- a/guides/upgrading/v0.11.md
+++ b/guides/upgrading/v0.11.md
@@ -292,7 +292,7 @@ Rename `Membrane.Time.to_<unit name>/1` into `Membrane.Time.round_to_<unit name>
 ```
 
 ## Update the children definitions
-Children defintions syntax (previously known as `ParentSpec`, after the name of a structure used to define children), that was used in `Membrane.Pipeline.Action.spec_t` and `Membrane.Bin.Action.spec_t` actions, has changed. 
+Children definitions syntax (previously known as `ParentSpec`, after the name of a structure used to define children), that was used in `Membrane.Pipeline.Action.spec_t` and `Membrane.Bin.Action.spec_t` actions, has changed. 
 Since there are quite a few changes concerning children definition, we have decided to present them in the subsections below.
 
 ### Update children names

--- a/lib/membrane/bin.ex
+++ b/lib/membrane/bin.ex
@@ -20,20 +20,20 @@ defmodule Membrane.Bin do
   require Membrane.Core.Message
   require Membrane.Logger
 
-  @type state_t :: any()
+  @type state :: any()
 
-  @type callback_return_t :: {[Action.t()], state_t()}
+  @type callback_return :: {[Action.t()], state()}
 
   @typedoc """
   Defines options that can be passed to `start_link/3` and received
   in `c:handle_init/2` callback.
   """
-  @type options_t :: struct | nil
+  @type options :: struct | nil
 
   @typedoc """
   Type that defines a bin name by which it is identified.
   """
-  @type name_t :: tuple() | atom()
+  @type name :: tuple() | atom()
 
   @doc """
   Callback invoked on initialization of bin.
@@ -44,8 +44,8 @@ defmodule Membrane.Bin do
   while `handle_init` should be used for things like parsing options, initializing state or
   spawning children.
   """
-  @callback handle_init(context :: CallbackContext.t(), options :: options_t) ::
-              callback_return_t()
+  @callback handle_init(context :: CallbackContext.t(), options :: options) ::
+              callback_return()
 
   @doc """
   Callback that is called when new pad has been added to bin. Executed
@@ -54,10 +54,10 @@ defmodule Membrane.Bin do
   Context passed to this callback contains additional field `:pad_options`.
   """
   @callback handle_pad_added(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback that is called when some pad of the bin has been removed. Executed
@@ -66,10 +66,10 @@ defmodule Membrane.Bin do
   Context passed to this callback contains additional field `:pad_options`.
   """
   @callback handle_pad_removed(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked on bin startup, right after `c:handle_init/2`.
@@ -78,27 +78,27 @@ defmodule Membrane.Bin do
   """
   @callback handle_setup(
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when bin switches the playback to `:playing`.
   """
   @callback handle_playing(
               context :: CallbackContext.t(),
-              state :: state_t
+              state :: state
             ) ::
-              callback_return_t
+              callback_return
 
   @doc """
   Callback invoked when a notification comes in from an element.
   """
   @callback handle_child_notification(
               notification :: Membrane.ChildNotification.t(),
-              element :: Child.name_t(),
+              element :: Child.name(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when a notification comes in from an parent.
@@ -106,8 +106,8 @@ defmodule Membrane.Bin do
   @callback handle_parent_notification(
               notification :: Membrane.ParentNotification.t(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when bin receives a message that is not recognized
@@ -118,58 +118,58 @@ defmodule Membrane.Bin do
   @callback handle_info(
               message :: any,
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when a child element starts processing stream via given pad.
   """
   @callback handle_element_start_of_stream(
-              child :: Child.name_t(),
-              pad :: Pad.ref_t(),
+              child :: Child.name(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when a child element finishes processing stream via given pad.
   """
   @callback handle_element_end_of_stream(
-              child :: Child.name_t(),
-              pad :: Pad.ref_t(),
+              child :: Child.name(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   Callback invoked when children of `Membrane.ChildrenSpec` are started.
   """
   @callback handle_spec_started(
-              children :: [Child.name_t()],
+              children :: [Child.name()],
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
-  Callback invoked upon each timer tick. A timer can be started with `t:Membrane.Bin.Action.start_timer_t/0`
+  Callback invoked upon each timer tick. A timer can be started with `t:Membrane.Bin.Action.start_timer/0`
   action.
   """
   @callback handle_tick(
               timer_id :: any,
               context :: CallbackContext.t(),
-              state :: state_t
-            ) :: callback_return_t
+              state :: state
+            ) :: callback_return
 
   @doc """
   A callback invoked when the bin is being removed by its parent.
 
-  By default it returns `t:Membrane.Bin.Action.terminate_t/0` with reason `:normal`.
+  By default it returns `t:Membrane.Bin.Action.terminate/0` with reason `:normal`.
   """
   @callback handle_terminate_request(
               context :: CallbackContext.t(),
-              state_t
+              state
             ) ::
-              callback_return_t()
+              callback_return()
 
   @optional_callbacks handle_init: 2,
                       handle_pad_added: 3,

--- a/lib/membrane/bin/action.ex
+++ b/lib/membrane/bin/action.ex
@@ -19,18 +19,18 @@ defmodule Membrane.Bin.Action do
 
   Untils the setup lasts, the component won't enter `:playing` playback.
   """
-  @type setup_t :: {:setup, :incomplete | :complete}
+  @type setup :: {:setup, :incomplete | :complete}
 
   @typedoc """
   Action that sends a message to a child identified by name.
   """
-  @type notify_child_t ::
-          {:notify_child, {Child.name_t(), Membrane.ParentNotification.t()}}
+  @type notify_child ::
+          {:notify_child, {Child.name(), Membrane.ParentNotification.t()}}
 
   @typedoc """
   Sends a message to the parent.
   """
-  @type notify_parent_t :: {:notify_parent, Membrane.ChildNotification.t()}
+  @type notify_parent :: {:notify_parent, Membrane.ChildNotification.t()}
 
   @typedoc """
   Action that instantiates children and links them according to `Membrane.ChildrenSpec`.
@@ -38,7 +38,7 @@ defmodule Membrane.Bin.Action do
   Children's playback is changed to the current bin playback.
   `c:Membrane.Parent.handle_spec_started/3` callback is executed once the children are spawned.
   """
-  @type spec_t :: {:spec, ChildrenSpec.t()}
+  @type spec :: {:spec, ChildrenSpec.t()}
 
   @typedoc """
   Action that stops, unlinks and removes specified child/children from the bin.
@@ -46,65 +46,65 @@ defmodule Membrane.Bin.Action do
   A child ref, list of children refs, children group id or a list of children group ids can be specified
   as an argument. In case you need to refer to a single child from a children group, use `Membrane.Child.ref/2`.
   """
-  @type remove_children_t ::
+  @type remove_children ::
           {:remove_children,
-           Child.ref_t()
-           | [Child.ref_t()]
-           | Membrane.Child.group_t()
-           | [Membrane.Child.group_t()]}
+           Child.ref()
+           | [Child.ref()]
+           | Membrane.Child.group()
+           | [Membrane.Child.group()]}
 
   @typedoc """
   Action that removes link, which relates to specified child and pad.
 
   Removed link has to have dynamic pads on both ends.
   """
-  @type remove_link_t :: {:remove_link, {Child.name_t(), Pad.ref_t()}}
+  @type remove_link :: {:remove_link, {Child.name(), Pad.ref()}}
 
   @typedoc """
   Starts a timer that will invoke `c:Membrane.Bin.handle_tick/3` callback
   every `interval` according to the given `clock`.
 
   The timer's `id` is passed to the `c:Membrane.Bin.handle_tick/3`
-  callback and can be used for changing its interval via `t:timer_interval_t/0`
-  or stopping it via `t:stop_timer_t/0`.
+  callback and can be used for changing its interval via `t:timer_interval/0`
+  or stopping it via `t:stop_timer/0`.
 
   If `interval` is set to `:no_interval`, the timer won't issue any ticks until
-  the interval is set with `t:timer_interval_t/0` action.
+  the interval is set with `t:timer_interval/0` action.
 
   If no `clock` is passed, parent clock is chosen.
 
   Timers use `Process.send_after/3` under the hood.
   """
-  @type start_timer_t ::
+  @type start_timer ::
           {:start_timer,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}
-           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval,
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}
+           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval,
               clock :: Membrane.Clock.t()}}
 
   @typedoc """
-  Changes interval of a timer started with `t:start_timer_t/0`.
+  Changes interval of a timer started with `t:start_timer/0`.
 
   Permitted only from `c:Membrane.Bin.handle_tick/3`, unless the interval
   was previously set to `:no_interval`.
 
   If the `interval` is `:no_interval`, the timer won't issue any ticks until
-  another `t:timer_interval_t/0` action. Otherwise, the timer will issue ticks every
+  another `t:timer_interval/0` action. Otherwise, the timer will issue ticks every
   new `interval`. The next tick after interval change is scheduled at
   `new_interval + previous_time`, where previous_time is the time of the latest
-  tick or the time of returning `t:start_timer_t/0` action if no tick has been
+  tick or the time of returning `t:start_timer/0` action if no tick has been
   sent yet. Note that if `current_time - previous_time > new_interval`, a burst
   of `div(current_time - previous_time, new_interval)` ticks is issued immediately.
   """
-  @type timer_interval_t ::
+  @type timer_interval ::
           {:timer_interval,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}}
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}}
 
   @typedoc """
-  Stops a timer started with `t:start_timer_t/0` action.
+  Stops a timer started with `t:start_timer/0` action.
 
   This action is atomic: stopping timer guarantees that no ticks will arrive from it.
   """
-  @type stop_timer_t :: {:stop_timer, timer_id :: any}
+  @type stop_timer :: {:stop_timer, timer_id :: any}
 
   @typedoc """
   Terminates bin with given reason.
@@ -120,7 +120,7 @@ defmodule Membrane.Bin.Action do
   terminates all the children with the reason `:shutdown`
   - If the reason is neither `:normal`, `:shutdown` nor `{:shutdown, term}`, an error is logged
   """
-  @type terminate_t :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
+  @type terminate :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
 
   @typedoc """
   Type describing actions that can be returned from bin callbacks.
@@ -129,14 +129,14 @@ defmodule Membrane.Bin.Action do
   other parts of framework.
   """
   @type t ::
-          setup_t
-          | notify_child_t
-          | notify_parent_t
-          | spec_t
-          | remove_children_t
-          | remove_link_t
-          | start_timer_t
-          | timer_interval_t
-          | stop_timer_t
-          | terminate_t
+          setup
+          | notify_child
+          | notify_parent
+          | spec
+          | remove_children
+          | remove_link
+          | start_timer
+          | timer_interval
+          | stop_timer
+          | terminate
 end

--- a/lib/membrane/bin/callback_context.ex
+++ b/lib/membrane/bin/callback_context.ex
@@ -12,9 +12,9 @@ defmodule Membrane.Bin.CallbackContext do
   @type t :: %{
           :clock => Membrane.Clock.t(),
           :parent_clock => Membrane.Clock.t(),
-          :pads => %{Membrane.Pad.ref_t() => Membrane.Bin.PadData.t()},
-          :name => Membrane.Bin.name_t(),
-          :children => %{Membrane.Child.name_t() => Membrane.ChildEntry.t()},
+          :pads => %{Membrane.Pad.ref() => Membrane.Bin.PadData.t()},
+          :name => Membrane.Bin.name(),
+          :children => %{Membrane.Child.name() => Membrane.ChildEntry.t()},
           :playback => Membrane.Playback.t(),
           :resource_guard => Membrane.ResourceGuard.t(),
           :utility_supervisor => Membrane.UtilitySupervisor.t(),

--- a/lib/membrane/bin/pad_data.ex
+++ b/lib/membrane/bin/pad_data.ex
@@ -3,11 +3,11 @@ defmodule Membrane.Bin.PadData do
   Struct describing current pad state.
 
   The public fields are:
-    - `:availability` - see `t:Membrane.Pad.availability_t/0`
-    - `:direction` - see `t:Membrane.Pad.direction_t/0`
-    - `:name` - see `t:Membrane.Pad.name_t/0`. Do not mistake with `:ref`
+    - `:availability` - see `t:Membrane.Pad.availability/0`
+    - `:direction` - see `t:Membrane.Pad.direction/0`
+    - `:name` - see `t:Membrane.Pad.name/0`. Do not mistake with `:ref`
     - `:options` - options passed in `Membrane.ChildrenSpec` when linking pad
-    - `:ref` - see `t:Membrane.Pad.ref_t/0`
+    - `:ref` - see `t:Membrane.Pad.ref/0`
 
   Other fields in the struct ARE NOT PART OF THE PUBLIC API and should not be
   accessed or relied on.
@@ -17,11 +17,11 @@ defmodule Membrane.Bin.PadData do
   @type private_field :: term()
 
   @type t :: %__MODULE__{
-          ref: Membrane.Pad.ref_t(),
-          options: Membrane.ChildrenSpec.pad_options_t(),
-          availability: Membrane.Pad.availability_t(),
-          direction: Membrane.Pad.direction_t(),
-          name: Membrane.Pad.name_t(),
+          ref: Membrane.Pad.ref(),
+          options: Membrane.ChildrenSpec.pad_options(),
+          availability: Membrane.Pad.availability(),
+          direction: Membrane.Pad.direction(),
+          name: Membrane.Pad.name(),
           link_id: private_field,
           endpoint: private_field,
           linked?: private_field,

--- a/lib/membrane/buffer.ex
+++ b/lib/membrane/buffer.ex
@@ -11,13 +11,13 @@ defmodule Membrane.Buffer do
   alias Membrane.Payload
   alias Membrane.Time
 
-  @type metadata_t :: map
+  @type metadata :: map
 
   @type t :: %Buffer{
           pts: Time.t() | nil,
           dts: Time.t() | nil,
           payload: Payload.t(),
-          metadata: metadata_t
+          metadata: metadata
         }
 
   @enforce_keys [:payload]

--- a/lib/membrane/buffer/metric.ex
+++ b/lib/membrane/buffer/metric.ex
@@ -6,7 +6,7 @@ defmodule Membrane.Buffer.Metric do
   alias Membrane.Buffer
   alias __MODULE__
 
-  @type unit_t :: :buffers | :bytes
+  @type unit :: :buffers | :bytes
 
   @callback buffer_size_approximation() :: pos_integer
 
@@ -15,7 +15,7 @@ defmodule Membrane.Buffer.Metric do
   @callback split_buffers([%Buffer{}] | [], non_neg_integer) ::
               {[%Buffer{}] | [], [%Buffer{}] | []}
 
-  @spec from_unit(unit_t()) :: module()
+  @spec from_unit(unit()) :: module()
   def from_unit(:buffers), do: Metric.Count
   def from_unit(:bytes), do: Metric.ByteSize
 end

--- a/lib/membrane/child.ex
+++ b/lib/membrane/child.ex
@@ -8,20 +8,20 @@ defmodule Membrane.Child do
   alias Membrane.{Bin, Element}
   @default_ref_options [group: [default: nil]]
 
-  @type name_t :: Element.name_t() | Bin.name_t()
-  @type group_t() :: any()
-  @type ref_t :: {Membrane.Child, group_t(), name_t()} | name_t()
+  @type name :: Element.name() | Bin.name()
+  @type group() :: any()
+  @type ref :: {Membrane.Child, group(), name()} | name()
 
-  @type options_t :: Element.options_t() | Bin.options_t()
+  @type options :: Element.options() | Bin.options()
 
   defguard is_child_name?(arg) when is_element_name?(arg) or is_bin_name?(arg)
 
-  @type child_ref_options_t :: [group: group_t()]
+  @type child_ref_options :: [group: group()]
 
   @doc """
   Returns a reference to a child.
   """
-  @spec ref(name_t(), child_ref_options_t()) :: ref_t()
+  @spec ref(name(), child_ref_options()) :: ref()
   def ref(name, options \\ []) do
     validate_name!(name)
     {:ok, options} = Bunch.Config.parse(options, @default_ref_options)

--- a/lib/membrane/child_entry.ex
+++ b/lib/membrane/child_entry.ex
@@ -14,7 +14,7 @@ defmodule Membrane.ChildEntry do
   use Bunch.Access
 
   @type t :: %__MODULE__{
-          name: Membrane.Child.name_t(),
+          name: Membrane.Child.name(),
           module: module,
           options: struct | nil,
           component_type: :element | :bin,
@@ -22,7 +22,7 @@ defmodule Membrane.ChildEntry do
           clock: Membrane.Clock.t(),
           sync: Membrane.Sync.t(),
           terminating?: boolean(),
-          group: Membrane.Child.group_t()
+          group: Membrane.Child.group()
         }
 
   defstruct [

--- a/lib/membrane/clock.ex
+++ b/lib/membrane/clock.ex
@@ -3,7 +3,7 @@ defmodule Membrane.Clock do
   Clock is a Membrane utility that allows elements to measure time according to
   a particular clock, which can be e.g. a soundcard hardware clock.
 
-  Internally, Clock is a GenServer process that can receive _updates_ (see `t:update_message_t/0`),
+  Internally, Clock is a GenServer process that can receive _updates_ (see `t:update_message/0`),
   which are messages containing amount of time until the next update.
   For example, a sink playing audio to the sound card can send an update before
   each write to the sound card buffer (for practical reasons that can be done every
@@ -11,12 +11,12 @@ defmodule Membrane.Clock do
   the time passed, in practice the described approach turns out to be more convenient,
   as it simplifies the first update.
 
-  Basing on updates, Clock calculates the `t:ratio_t/0` of its time to the reference
+  Basing on updates, Clock calculates the `t:ratio/0` of its time to the reference
   time. The reference time can be configured with `:time_provider` option. The ratio
-  is broadcasted (see `t:ratio_message_t/0`) to _subscribers_ (see `subscribe/2`)
+  is broadcasted (see `t:ratio_message/0`) to _subscribers_ (see `subscribe/2`)
   - processes willing to synchronize to the custom clock. Subscribers can adjust
   their timers according to received ratio - timers started with
-  `t:Membrane.Element.Action.start_timer_t/0` action in elements do it automatically.
+  `t:Membrane.Element.Action.start_timer/0` action in elements do it automatically.
   Initial ratio is equal to 1, which means that if no updates are received,
   Clock is synchronized to the reference time.
 
@@ -37,24 +37,24 @@ defmodule Membrane.Clock do
   @typedoc """
   Ratio of the Clock time to the reference time.
   """
-  @type ratio_t :: Ratio.t()
+  @type ratio :: Ratio.t()
 
   @typedoc """
   Update message received by the Clock. It should contain the time till the next
   update.
   """
-  @type update_message_t ::
+  @type update_message ::
           {:membrane_clock_update,
            milliseconds ::
              non_neg_integer
-             | ratio_t
+             | ratio
              | {numerator :: non_neg_integer, denominator :: pos_integer()}}
 
   @typedoc """
   Ratio message sent by the Clock to all its subscribers. It contains the ratio
   of the custom clock time to the reference time.
   """
-  @type ratio_message_t :: {:membrane_clock_ratio, clock :: pid, ratio_t}
+  @type ratio_message :: {:membrane_clock_ratio, clock :: pid, ratio}
 
   @typedoc """
   Options accepted by `start_link/2` and `start/2` functions.
@@ -66,23 +66,23 @@ defmodule Membrane.Clock do
 
   Check the moduledoc for more details.
   """
-  @type option_t ::
+  @type option ::
           {:time_provider, (() -> Time.t())}
           | {:proxy, boolean}
           | {:proxy_for, pid | nil}
 
-  @spec start_link([option_t], GenServer.options()) :: GenServer.on_start()
+  @spec start_link([option], GenServer.options()) :: GenServer.on_start()
   def start_link(options \\ [], gen_server_options \\ []) do
     GenServer.start_link(__MODULE__, options, gen_server_options)
   end
 
-  @spec start([option_t], GenServer.options()) :: GenServer.on_start()
+  @spec start([option], GenServer.options()) :: GenServer.on_start()
   def start(options \\ [], gen_server_options \\ []) do
     GenServer.start(__MODULE__, options, gen_server_options)
   end
 
   @doc """
-  Subscribes `pid` for receiving `t:ratio_message_t/0` messages from the clock.
+  Subscribes `pid` for receiving `t:ratio_message/0` messages from the clock.
 
   This function can be called multiple times from the same process. To unsubscribe,
   `unsubscribe/2` should be called the same amount of times. The subscribed pid
@@ -94,7 +94,7 @@ defmodule Membrane.Clock do
   end
 
   @doc """
-  Unsubscribes `pid` from receiving `t:ratio_message_t/0` messages from the clock.
+  Unsubscribes `pid` from receiving `t:ratio_message/0` messages from the clock.
 
   For unsubscription to take effect, `unsubscribe/2` should be called the same
   amount of times as `subscribe/2`.

--- a/lib/membrane/component_path.ex
+++ b/lib/membrane/component_path.ex
@@ -5,7 +5,7 @@ defmodule Membrane.ComponentPath do
   Information is being stored in a process dictionary and can be set/appended to.
   """
 
-  @type path_t :: list(String.t())
+  @type path :: list(String.t())
 
   @key :membrane_path
 
@@ -14,7 +14,7 @@ defmodule Membrane.ComponentPath do
 
   If path had already existed then replaces it.
   """
-  @spec set(path_t) :: :ok
+  @spec set(path) :: :ok
   def set(path) do
     Process.put(@key, path)
     :ok
@@ -23,7 +23,7 @@ defmodule Membrane.ComponentPath do
   @doc """
   Returns formatted string of given path's names.
   """
-  @spec format(path_t()) :: String.t()
+  @spec format(path()) :: String.t()
   def format(path) do
     Enum.join(path)
   end

--- a/lib/membrane/core/bin.ex
+++ b/lib/membrane/core/bin.ex
@@ -22,14 +22,14 @@ defmodule Membrane.Core.Bin do
   require Membrane.Core.Telemetry
   require Membrane.Logger
 
-  @type options_t :: %{
+  @type options :: %{
           name: atom,
           module: module,
           node: node | nil,
           parent: pid,
-          user_options: Membrane.Bin.options_t(),
+          user_options: Membrane.Bin.options(),
           parent_clock: Membrane.Clock.t(),
-          parent_path: Membrane.ComponentPath.path_t(),
+          parent_path: Membrane.ComponentPath.path(),
           log_metadata: Logger.metadata(),
           sync: :membrane_no_sync,
           subprocess_supervisor: pid(),
@@ -45,7 +45,7 @@ defmodule Membrane.Core.Bin do
 
   Returns the same values as `GenServer.start_link/3`.
   """
-  @spec start_link(options_t) :: GenServer.on_start()
+  @spec start_link(options) :: GenServer.on_start()
   def start_link(options),
     do: do_start(:start_link, options)
 
@@ -53,7 +53,7 @@ defmodule Membrane.Core.Bin do
   Works similarly to `start_link/3`, but does not link to the current process.
   """
 
-  @spec start(options_t()) :: GenServer.on_start()
+  @spec start(options()) :: GenServer.on_start()
   def start(options),
     do: do_start(:start, options)
 

--- a/lib/membrane/core/bin/callback_context.ex
+++ b/lib/membrane/core/bin/callback_context.ex
@@ -1,9 +1,9 @@
 defmodule Membrane.Core.Bin.CallbackContext do
   @moduledoc false
 
-  @type optional_fields_t :: [pad_options: map()]
+  @type optional_fields :: [pad_options: map()]
 
-  @spec from_state(Membrane.Core.Bin.State.t(), optional_fields_t()) ::
+  @spec from_state(Membrane.Core.Bin.State.t(), optional_fields()) ::
           Membrane.Bin.CallbackContext.t()
   def from_state(state, optional_fields \\ []) do
     Map.new(optional_fields)

--- a/lib/membrane/core/bin/pad_controller.ex
+++ b/lib/membrane/core/bin/pad_controller.ex
@@ -21,10 +21,10 @@ defmodule Membrane.Core.Bin.PadController do
   Handles a link request from the bin's parent.
   """
   @spec handle_external_link_request(
-          Pad.ref_t(),
-          Pad.direction_t(),
+          Pad.ref(),
+          Pad.direction(),
           Link.id(),
-          Membrane.ChildrenSpec.pad_options_t(),
+          Membrane.ChildrenSpec.pad_options(),
           State.t()
         ) :: State.t() | no_return
   def handle_external_link_request(pad_ref, direction, link_id, pad_options, state) do
@@ -80,7 +80,7 @@ defmodule Membrane.Core.Bin.PadController do
     state
   end
 
-  @spec handle_linking_timeout(Pad.ref_t(), State.t()) :: :ok | no_return()
+  @spec handle_linking_timeout(Pad.ref(), State.t()) :: :ok | no_return()
   def handle_linking_timeout(pad_ref, state) do
     case PadModel.get_data(state, pad_ref) do
       {:ok, %{endpoint: nil}} = pad_data ->
@@ -97,9 +97,9 @@ defmodule Membrane.Core.Bin.PadController do
   to a pad of one of its children.
   """
   @spec handle_internal_link_request(
-          Pad.ref_t(),
+          Pad.ref(),
           Link.Endpoint.t(),
-          ChildLifeController.spec_ref_t(),
+          ChildLifeController.spec_ref(),
           State.t()
         ) :: State.t()
   def handle_internal_link_request(pad_ref, child_endpoint, spec_ref, state) do
@@ -136,7 +136,7 @@ defmodule Membrane.Core.Bin.PadController do
   @doc """
   Sends link response to the parent for each of bin's pads involved in given spec.
   """
-  @spec respond_links(ChildLifeController.spec_ref_t(), State.t()) :: State.t()
+  @spec respond_links(ChildLifeController.spec_ref(), State.t()) :: State.t()
   def respond_links(spec_ref, state) do
     state.pads_data
     |> Map.values()
@@ -163,7 +163,7 @@ defmodule Membrane.Core.Bin.PadController do
   @doc """
   Returns true if all pads of given `spec_ref` are linked, false otherwise.
   """
-  @spec all_pads_linked?(ChildLifeController.spec_ref_t(), State.t()) :: boolean()
+  @spec all_pads_linked?(ChildLifeController.spec_ref(), State.t()) :: boolean()
   def all_pads_linked?(spec_ref, state) do
     state.pads_data
     |> Map.values()
@@ -175,23 +175,23 @@ defmodule Membrane.Core.Bin.PadController do
   Verifies linked pad and proxies the message to the proper child.
   """
   @spec handle_link(
-          Pad.direction_t(),
-          SpecificationParser.raw_endpoint_t(),
-          SpecificationParser.raw_endpoint_t(),
+          Pad.direction(),
+          SpecificationParser.raw_endpoint(),
+          SpecificationParser.raw_endpoint(),
           %{
             initiator: :parent,
             stream_format_validation_params:
-              StreamFormatController.stream_format_validation_params_t()
+              StreamFormatController.stream_format_validation_params()
           }
           | %{
               initiator: :sibling,
-              other_info: PadModel.pad_info_t() | nil,
+              other_info: PadModel.pad_info() | nil,
               link_metadata: map,
               stream_format_validation_params:
-                StreamFormatController.stream_format_validation_params_t()
+                StreamFormatController.stream_format_validation_params()
             },
           Core.Bin.State.t()
-        ) :: {Core.Element.PadController.link_call_reply_t(), Core.Bin.State.t()}
+        ) :: {Core.Element.PadController.link_call_reply(), Core.Bin.State.t()}
   def handle_link(direction, endpoint, other_endpoint, params, state) do
     pad_data = PadModel.get_data!(state, endpoint.pad_ref)
 
@@ -250,7 +250,7 @@ defmodule Membrane.Core.Bin.PadController do
   @doc """
   Handles situation where the pad has been unlinked (e.g. when connected element has been removed from the pipeline)
   """
-  @spec handle_unlink(Pad.ref_t(), Core.Bin.State.t()) :: Core.Bin.State.t()
+  @spec handle_unlink(Pad.ref(), Core.Bin.State.t()) :: Core.Bin.State.t()
   def handle_unlink(pad_ref, state) do
     with {:ok, %{availability: :on_request}} <- PadModel.get_data(state, pad_ref) do
       state = maybe_handle_pad_removed(pad_ref, state)
@@ -285,7 +285,7 @@ defmodule Membrane.Core.Bin.PadController do
     end
   end
 
-  @spec maybe_handle_pad_added(Pad.ref_t(), Core.Bin.State.t()) :: Core.Bin.State.t()
+  @spec maybe_handle_pad_added(Pad.ref(), Core.Bin.State.t()) :: Core.Bin.State.t()
   defp maybe_handle_pad_added(ref, state) do
     %{options: pad_opts, availability: availability} = PadModel.get_data!(state, ref)
 
@@ -304,7 +304,7 @@ defmodule Membrane.Core.Bin.PadController do
     end
   end
 
-  @spec maybe_handle_pad_removed(Pad.ref_t(), Core.Bin.State.t()) :: Core.Bin.State.t()
+  @spec maybe_handle_pad_removed(Pad.ref(), Core.Bin.State.t()) :: Core.Bin.State.t()
   defp maybe_handle_pad_removed(ref, state) do
     %{availability: availability} = PadModel.get_data!(state, ref)
 

--- a/lib/membrane/core/bin/state.ex
+++ b/lib/membrane/core/bin/state.ex
@@ -15,31 +15,31 @@ defmodule Membrane.Core.Bin.State do
   alias Membrane.Core.Timer
 
   @type t :: %__MODULE__{
-          internal_state: Membrane.Bin.state_t() | nil,
+          internal_state: Membrane.Bin.state() | nil,
           module: module,
-          children: ChildrenModel.children_t(),
+          children: ChildrenModel.children(),
           subprocess_supervisor: pid(),
-          name: Membrane.Bin.name_t() | nil,
-          pads_info: PadModel.pads_info_t() | nil,
-          pads_data: PadModel.pads_data_t() | nil,
+          name: Membrane.Bin.name() | nil,
+          pads_info: PadModel.pads_info() | nil,
+          pads_data: PadModel.pads_data() | nil,
           parent_pid: pid,
           links: %{Link.id() => Link.t()},
-          crash_groups: %{CrashGroup.name_t() => CrashGroup.t()},
+          crash_groups: %{CrashGroup.name() => CrashGroup.t()},
           synchronization: %{
-            timers: %{Timer.id_t() => Timer.t()},
+            timers: %{Timer.id() => Timer.t()},
             parent_clock: Clock.t(),
-            latency: Membrane.Time.non_neg_t(),
+            latency: Membrane.Time.non_neg(),
             stream_sync: Sync.t(),
             clock: Clock.t() | nil,
             clock_proxy: Clock.t(),
             clock_provider: %{
               clock: Clock.t() | nil,
-              provider: Child.name_t() | nil,
+              provider: Child.name() | nil,
               choice: :auto | :manual
             }
           },
           children_log_metadata: Keyword.t(),
-          pending_specs: ChildLifeController.pending_specs_t(),
+          pending_specs: ChildLifeController.pending_specs(),
           playback: Membrane.Playback.t(),
           initialized?: boolean(),
           terminating?: boolean(),

--- a/lib/membrane/core/bin/zombie.ex
+++ b/lib/membrane/core/bin/zombie.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Core.Bin.Zombie do
   @moduledoc false
-  # When a bin returns Membrane.Bin.Action.terminate_t() and becomes a zombie
+  # When a bin returns Membrane.Bin.Action.terminate() and becomes a zombie
   # this module is used to replace the user implementation of the bin
   use Membrane.Bin
   require Membrane.Logger

--- a/lib/membrane/core/callback_handler.ex
+++ b/lib/membrane/core/callback_handler.ex
@@ -11,24 +11,24 @@ defmodule Membrane.Core.CallbackHandler do
 
   require Membrane.Logger
 
-  @type state_t :: %{
+  @type state :: %{
           :module => module,
-          :internal_state => internal_state_t,
+          :internal_state => internal_state,
           optional(atom) => any
         }
 
-  @type internal_state_t :: any
+  @type internal_state :: any
 
-  @type callback_return_t(action, internal_state) ::
+  @type callback_return(action, internal_state) ::
           {[action], internal_state}
 
-  @type callback_return_t :: callback_return_t(any, any)
+  @type callback_return :: callback_return(any, any)
 
-  @type handler_params_t :: map
+  @type handler_params :: map
 
-  @callback handle_action(action :: any, callback :: atom, handler_params_t, state_t) :: state_t
-  @callback transform_actions(actions :: list, callback :: atom, handler_params_t, state_t) ::
-              {actions :: list, state_t}
+  @callback handle_action(action :: any, callback :: atom, handler_params, state) :: state
+  @callback transform_actions(actions :: list, callback :: atom, handler_params, state) ::
+              {actions :: list, state}
 
   defmacro __using__(_args) do
     quote location: :keep do
@@ -47,10 +47,10 @@ defmodule Membrane.Core.CallbackHandler do
   @spec exec_and_handle_callback(
           callback :: atom,
           module,
-          handler_params_t,
+          handler_params,
           args :: list,
-          state_t
-        ) :: state_t
+          state
+        ) :: state
   def exec_and_handle_callback(
         callback,
         handler_module,
@@ -67,10 +67,10 @@ defmodule Membrane.Core.CallbackHandler do
           callback :: atom,
           original_callback :: atom,
           module,
-          handler_params_t,
+          handler_params,
           args_list :: list,
-          state_t
-        ) :: state_t
+          state
+        ) :: state
   def exec_and_handle_split_callback(
         callback,
         original_callback,
@@ -117,8 +117,8 @@ defmodule Membrane.Core.CallbackHandler do
     end)
   end
 
-  @spec exec_callback(callback :: atom, args :: list, handler_params_t, state_t) ::
-          {list, internal_state_t}
+  @spec exec_callback(callback :: atom, args :: list, handler_params, state) ::
+          {list, internal_state}
   defp exec_callback(
          callback,
          args,
@@ -160,12 +160,12 @@ defmodule Membrane.Core.CallbackHandler do
   end
 
   @spec handle_callback_result(
-          {actions :: Keyword.t(), internal_state_t},
+          {actions :: Keyword.t(), internal_state},
           callback :: atom,
           module,
-          handler_params_t,
-          state_t
-        ) :: state_t
+          handler_params,
+          state
+        ) :: state
   defp handle_callback_result(cb_result, callback, handler_module, handler_params, state) do
     {actions, new_internal_state} = cb_result
     state = %{state | internal_state: new_internal_state}

--- a/lib/membrane/core/child.ex
+++ b/lib/membrane/core/child.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.Core.Child do
   @moduledoc false
 
-  @type state_t :: Membrane.Core.Element.State.t() | Membrane.Core.Bin.State.t()
+  @type state :: Membrane.Core.Element.State.t() | Membrane.Core.Bin.State.t()
 
   @docs_order [
     :membrane_options_moduledoc,

--- a/lib/membrane/core/child/lifecycle_controller.ex
+++ b/lib/membrane/core/child/lifecycle_controller.ex
@@ -4,8 +4,8 @@ defmodule Membrane.Core.Child.LifecycleController do
 
   require Membrane.Core.Component
 
-  @spec handle_parent_notification(Membrane.ParentNotification.t(), Membrane.Core.Child.state_t()) ::
-          Membrane.Core.Child.state_t()
+  @spec handle_parent_notification(Membrane.ParentNotification.t(), Membrane.Core.Child.state()) ::
+          Membrane.Core.Child.state()
   def handle_parent_notification(notification, state) do
     action_handler = Component.action_handler(state)
 

--- a/lib/membrane/core/child/pad_controller.ex
+++ b/lib/membrane/core/child/pad_controller.ex
@@ -7,11 +7,11 @@ defmodule Membrane.Core.Child.PadController do
   require Membrane.Core.Child.PadModel
   require Membrane.Logger
 
-  @type state_t :: Membrane.Core.Bin.State.t() | Membrane.Core.Element.State.t()
+  @type state :: Membrane.Core.Bin.State.t() | Membrane.Core.Element.State.t()
 
   @spec validate_pad_being_linked!(
-          Pad.direction_t(),
-          PadModel.pad_info_t()
+          Pad.direction(),
+          PadModel.pad_info()
         ) :: :ok
   def validate_pad_being_linked!(direction, info) do
     if info.direction != direction do
@@ -26,8 +26,8 @@ defmodule Membrane.Core.Child.PadController do
   end
 
   @spec validate_pad_mode!(
-          {Pad.ref_t(), info :: PadModel.pad_info_t() | PadModel.pad_data_t()},
-          {Pad.ref_t(), other_info :: PadModel.pad_info_t() | PadModel.pad_data_t()}
+          {Pad.ref(), info :: PadModel.pad_info() | PadModel.pad_data()},
+          {Pad.ref(), other_info :: PadModel.pad_info() | PadModel.pad_data()}
         ) :: :ok
   def validate_pad_mode!(this, that) do
     :ok = do_validate_pad_mode!(this, that)
@@ -48,7 +48,7 @@ defmodule Membrane.Core.Child.PadController do
     :ok
   end
 
-  @spec parse_pad_options!(Pad.name_t(), Membrane.ChildrenSpec.pad_options_t(), state_t()) ::
+  @spec parse_pad_options!(Pad.name(), Membrane.ChildrenSpec.pad_options(), state()) ::
           map | no_return
   def parse_pad_options!(pad_name, options, state) do
     {_pad_name, pad_spec} =
@@ -70,7 +70,7 @@ defmodule Membrane.Core.Child.PadController do
     end
   end
 
-  @spec assert_all_static_pads_linked!(state_t) :: :ok
+  @spec assert_all_static_pads_linked!(state) :: :ok
   def assert_all_static_pads_linked!(state) do
     linked_pads_names = state.pads_data |> Map.values() |> MapSet.new(& &1.name)
 

--- a/lib/membrane/core/child/pad_model.ex
+++ b/lib/membrane/core/child/pad_model.ex
@@ -8,63 +8,63 @@ defmodule Membrane.Core.Child.PadModel do
   alias Membrane.Core.Child
   alias Membrane.{Pad, UnknownPadError}
 
-  @type bin_pad_data_t :: %Membrane.Bin.PadData{
-          ref: Membrane.Pad.ref_t(),
-          options: Membrane.ChildrenSpec.pad_options_t(),
+  @type bin_pad_data :: %Membrane.Bin.PadData{
+          ref: Membrane.Pad.ref(),
+          options: Membrane.ChildrenSpec.pad_options(),
           link_id: Membrane.Core.Parent.Link.id(),
           endpoint: Membrane.Core.Parent.Link.Endpoint.t() | nil,
           linked?: boolean(),
           response_received?: boolean(),
-          spec_ref: Membrane.Core.Parent.ChildLifeController.spec_ref_t(),
-          availability: Pad.availability_t(),
-          direction: Pad.direction_t(),
-          name: Pad.name_t()
+          spec_ref: Membrane.Core.Parent.ChildLifeController.spec_ref(),
+          availability: Pad.availability(),
+          direction: Pad.direction(),
+          name: Pad.name()
         }
 
-  @type element_pad_data_t :: %Membrane.Element.PadData{
-          availability: Pad.availability_t(),
+  @type element_pad_data :: %Membrane.Element.PadData{
+          availability: Pad.availability(),
           stream_format: Membrane.StreamFormat.t() | nil,
           demand: integer() | nil,
           start_of_stream?: boolean(),
           end_of_stream?: boolean(),
-          direction: Pad.direction_t(),
-          flow_control: Pad.flow_control_t(),
-          name: Pad.name_t(),
-          ref: Pad.ref_t(),
-          demand_unit: Membrane.Buffer.Metric.unit_t() | nil,
-          other_demand_unit: Membrane.Buffer.Metric.unit_t() | nil,
+          direction: Pad.direction(),
+          flow_control: Pad.flow_control(),
+          name: Pad.name(),
+          ref: Pad.ref(),
+          demand_unit: Membrane.Buffer.Metric.unit() | nil,
+          other_demand_unit: Membrane.Buffer.Metric.unit() | nil,
           pid: pid,
-          other_ref: Pad.ref_t(),
+          other_ref: Pad.ref(),
           sticky_messages: [Membrane.Event.t()],
           input_queue: Membrane.Core.Element.InputQueue.t() | nil,
           options: %{optional(atom) => any},
           toilet: Membrane.Core.Element.Toilet.t() | nil,
           auto_demand_size: pos_integer() | nil,
-          associated_pads: [Pad.ref_t()] | nil,
+          associated_pads: [Pad.ref()] | nil,
           sticky_events: [Membrane.Event.t()]
         }
 
-  @type pad_data_t :: bin_pad_data_t | element_pad_data_t
+  @type pad_data :: bin_pad_data | element_pad_data
 
-  @type pads_data_t :: %{Pad.ref_t() => pad_data_t}
+  @type pads_data :: %{Pad.ref() => pad_data}
 
-  @type pad_info_t :: %{
-          required(:availability) => Pad.availability_t(),
-          required(:direction) => Pad.direction_t(),
-          required(:name) => Pad.name_t(),
-          optional(:flow_control) => Pad.flow_control_t(),
-          optional(:demand_unit) => Membrane.Buffer.Metric.unit_t(),
-          optional(:other_demand_unit) => Membrane.Buffer.Metric.unit_t()
+  @type pad_info :: %{
+          required(:availability) => Pad.availability(),
+          required(:direction) => Pad.direction(),
+          required(:name) => Pad.name(),
+          optional(:flow_control) => Pad.flow_control(),
+          optional(:demand_unit) => Membrane.Buffer.Metric.unit(),
+          optional(:other_demand_unit) => Membrane.Buffer.Metric.unit()
         }
 
-  @type pads_info_t :: %{Pad.name_t() => pad_info_t}
+  @type pads_info :: %{Pad.name() => pad_info}
 
-  @spec assert_instance(Child.state_t(), Pad.ref_t()) ::
+  @spec assert_instance(Child.state(), Pad.ref()) ::
           :ok | {:error, :unknown_pad}
   def assert_instance(%{pads_data: data}, pad_ref) when is_map_key(data, pad_ref), do: :ok
   def assert_instance(_state, _pad_ref), do: {:error, :unknown_pad}
 
-  @spec assert_instance!(Child.state_t(), Pad.ref_t()) :: :ok
+  @spec assert_instance!(Child.state(), Pad.ref()) :: :ok
   def assert_instance!(state, pad_ref) do
     :ok = assert_instance(state, pad_ref)
   end
@@ -101,7 +101,7 @@ defmodule Membrane.Core.Child.PadModel do
     end
   end
 
-  @spec filter_refs_by_data(Child.state_t(), constraints :: map) :: [Pad.ref_t()]
+  @spec filter_refs_by_data(Child.state(), constraints :: map) :: [Pad.ref()]
   def filter_refs_by_data(state, constraints \\ %{})
 
   def filter_refs_by_data(state, constraints) when constraints == %{} do
@@ -114,7 +114,7 @@ defmodule Membrane.Core.Child.PadModel do
     |> Keyword.keys()
   end
 
-  @spec filter_data(Child.state_t(), constraints :: map) :: %{atom => pad_data_t}
+  @spec filter_data(Child.state(), constraints :: map) :: %{atom => pad_data}
   def filter_data(state, constraints \\ %{})
 
   def filter_data(state, constraints) when constraints == %{} do
@@ -196,8 +196,8 @@ defmodule Membrane.Core.Child.PadModel do
       |> wrap_with_pad_check(pad_ref, state)
     end
   else
-    @spec get_data(Child.state_t(), Pad.ref_t()) ::
-            {:ok, pad_data_t() | any} | {:error, :unknown_pad}
+    @spec get_data(Child.state(), Pad.ref()) ::
+            {:ok, pad_data() | any} | {:error, :unknown_pad}
     def get_data(%{pads_data: data}, pad_ref) do
       case Map.fetch(data, pad_ref) do
         {:ok, pad_data} -> {:ok, pad_data}
@@ -205,8 +205,8 @@ defmodule Membrane.Core.Child.PadModel do
       end
     end
 
-    @spec get_data(Child.state_t(), Pad.ref_t(), keys :: atom | [atom]) ::
-            {:ok, pad_data_t | any} | {:error, :unknown_pad}
+    @spec get_data(Child.state(), Pad.ref(), keys :: atom | [atom]) ::
+            {:ok, pad_data | any} | {:error, :unknown_pad}
     def get_data(%{pads_data: data}, pad_ref, keys)
         when is_map_key(data, pad_ref) and is_list(keys) do
       data
@@ -223,20 +223,20 @@ defmodule Membrane.Core.Child.PadModel do
 
     def get_data(_state, _pad_ref, _keys), do: {:error, :unknown_pad}
 
-    @spec get_data!(Child.state_t(), Pad.ref_t()) :: pad_data_t | any
+    @spec get_data!(Child.state(), Pad.ref()) :: pad_data | any
     def get_data!(state, pad_ref) do
       {:ok, pad_data} = get_data(state, pad_ref)
       pad_data
     end
 
-    @spec get_data!(Child.state_t(), Pad.ref_t(), keys :: atom | [atom]) :: pad_data_t | any
+    @spec get_data!(Child.state(), Pad.ref(), keys :: atom | [atom]) :: pad_data | any
     def get_data!(state, pad_ref, keys) do
       {:ok, pad_data} = get_data(state, pad_ref, keys)
       pad_data
     end
 
-    @spec set_data(Child.state_t(), Pad.ref_t(), keys :: atom | [atom], value :: term()) ::
-            Bunch.Type.stateful_t(:ok | {:error, :unknown_pad}, Child.state_t())
+    @spec set_data(Child.state(), Pad.ref(), keys :: atom | [atom], value :: term()) ::
+            Bunch.Type.stateful_t(:ok | {:error, :unknown_pad}, Child.state())
     def set_data(state, pad_ref, keys \\ [], value) do
       case assert_instance(state, pad_ref) do
         :ok ->
@@ -248,21 +248,21 @@ defmodule Membrane.Core.Child.PadModel do
       end
     end
 
-    @spec set_data!(Child.state_t(), Pad.ref_t(), keys :: atom | [atom], value :: term()) ::
-            Child.state_t()
+    @spec set_data!(Child.state(), Pad.ref(), keys :: atom | [atom], value :: term()) ::
+            Child.state()
     def set_data!(state, pad_ref, keys \\ [], value) do
       {:ok, state} = set_data(state, pad_ref, keys, value)
       state
     end
 
     @spec update_data(
-            Child.state_t(),
-            Pad.ref_t(),
+            Child.state(),
+            Pad.ref(),
             keys :: atom | [atom],
             (data -> {:ok | error, data})
           ) ::
-            Bunch.Type.stateful_t(:ok | error | {:error, :unknown_pad}, Child.state_t())
-          when data: pad_data_t | any, error: {:error, reason :: any}
+            Bunch.Type.stateful_t(:ok | error | {:error, :unknown_pad}, Child.state())
+          when data: pad_data | any, error: {:error, reason :: any}
     def update_data(state, pad_ref, keys \\ [], f) do
       case assert_instance(state, pad_ref) do
         :ok ->
@@ -273,9 +273,9 @@ defmodule Membrane.Core.Child.PadModel do
       end
     end
 
-    @spec update_data!(Child.state_t(), Pad.ref_t(), keys :: atom | [atom], (data -> data)) ::
-            Child.state_t()
-          when data: pad_data_t | any
+    @spec update_data!(Child.state(), Pad.ref(), keys :: atom | [atom], (data -> data)) ::
+            Child.state()
+          when data: pad_data | any
     def update_data!(state, pad_ref, keys \\ [], f) do
       :ok = assert_instance(state, pad_ref)
 
@@ -284,12 +284,12 @@ defmodule Membrane.Core.Child.PadModel do
     end
 
     @spec get_and_update_data(
-            Child.state_t(),
-            Pad.ref_t(),
+            Child.state(),
+            Pad.ref(),
             keys :: atom | [atom],
             (data -> {success | error, data})
-          ) :: Bunch.Type.stateful_t(success | error | {:error, :unknown_pad}, Child.state_t())
-          when data: pad_data_t | any, success: {:ok, data}, error: {:error, reason :: any}
+          ) :: Bunch.Type.stateful_t(success | error | {:error, :unknown_pad}, Child.state())
+          when data: pad_data | any, success: {:ok, data}, error: {:error, reason :: any}
     def get_and_update_data(state, pad_ref, keys \\ [], f) do
       case assert_instance(state, pad_ref) do
         :ok ->
@@ -302,12 +302,12 @@ defmodule Membrane.Core.Child.PadModel do
     end
 
     @spec get_and_update_data!(
-            Child.state_t(),
-            Pad.ref_t(),
+            Child.state(),
+            Pad.ref(),
             keys :: atom | [atom],
             (data -> {data, data})
-          ) :: Bunch.Type.stateful_t(data, Child.state_t())
-          when data: pad_data_t | any
+          ) :: Bunch.Type.stateful_t(data, Child.state())
+          when data: pad_data | any
     def get_and_update_data!(state, pad_ref, keys \\ [], f) do
       :ok = assert_instance(state, pad_ref)
 
@@ -315,7 +315,7 @@ defmodule Membrane.Core.Child.PadModel do
       |> get_and_update_in(data_keys(pad_ref, keys), f)
     end
 
-    @spec data_keys(Pad.ref_t(), keys :: atom | [atom]) :: [atom]
+    @spec data_keys(Pad.ref(), keys :: atom | [atom]) :: [atom]
     @compile {:inline, data_keys: 2}
     defp data_keys(pad_ref, keys)
 
@@ -328,8 +328,8 @@ defmodule Membrane.Core.Child.PadModel do
     end
   end
 
-  @spec pop_data(Child.state_t(), Pad.ref_t()) ::
-          {{:ok, pad_data_t} | {:error, :unknown_pad}, Child.state_t()}
+  @spec pop_data(Child.state(), Pad.ref()) ::
+          {{:ok, pad_data} | {:error, :unknown_pad}, Child.state()}
   def pop_data(state, pad_ref) do
     with :ok <- assert_instance(state, pad_ref) do
       {data, state} = pop_in(state, [:pads_data, pad_ref])
@@ -339,7 +339,7 @@ defmodule Membrane.Core.Child.PadModel do
     end
   end
 
-  @spec pop_data!(Child.state_t(), Pad.ref_t()) :: {pad_data_t, Child.state_t()}
+  @spec pop_data!(Child.state(), Pad.ref()) :: {pad_data, Child.state()}
   def pop_data!(state, pad_ref) do
     case pop_data(state, pad_ref) do
       {{:ok, pad_data}, state} -> {pad_data, state}
@@ -347,21 +347,21 @@ defmodule Membrane.Core.Child.PadModel do
     end
   end
 
-  @spec delete_data(Child.state_t(), Pad.ref_t()) ::
-          {:ok | {:error, :unknown_pad}, Child.state_t()}
+  @spec delete_data(Child.state(), Pad.ref()) ::
+          {:ok | {:error, :unknown_pad}, Child.state()}
   def delete_data(state, pad_ref) do
     with {{:ok, _out}, state} <- pop_data(state, pad_ref) do
       {:ok, state}
     end
   end
 
-  @spec delete_data!(Child.state_t(), Pad.ref_t()) :: Child.state_t()
+  @spec delete_data!(Child.state(), Pad.ref()) :: Child.state()
   def delete_data!(state, pad_ref) do
     {_data, state} = pop_data!(state, pad_ref)
     state
   end
 
-  @spec constraints_met?(pad_data_t, map) :: boolean
+  @spec constraints_met?(pad_data, map) :: boolean
   defp constraints_met?(data, constraints) do
     constraints |> Enum.all?(fn {k, v} -> data[k] === v end)
   end

--- a/lib/membrane/core/child/pad_spec_handler.ex
+++ b/lib/membrane/core/child/pad_spec_handler.ex
@@ -25,7 +25,7 @@ defmodule Membrane.Core.Child.PadSpecHandler do
     }
   end
 
-  @spec get_pads(Child.state_t()) :: [{Pad.name_t(), Pad.description_t()}]
+  @spec get_pads(Child.state()) :: [{Pad.name(), Pad.description()}]
   def get_pads(%Bin.State{module: module}) do
     module.membrane_pads()
   end

--- a/lib/membrane/core/child/pads_specs.ex
+++ b/lib/membrane/core/child/pads_specs.ex
@@ -13,12 +13,12 @@ defmodule Membrane.Core.Child.PadsSpecs do
   @doc """
   Returns documentation string common for both input and output pads
   """
-  @spec def_pad_docs(Pad.direction_t(), :bin | :element) :: String.t()
+  @spec def_pad_docs(Pad.direction(), :bin | :element) :: String.t()
   def def_pad_docs(direction, component) do
     {entity, pad_type_spec} =
       case component do
-        :bin -> {"bin", "bin_spec_t/0"}
-        :element -> {"element", "element_spec_t/0"}
+        :bin -> {"bin", "bin_spec/0"}
+        :element -> {"element", "element_spec/0"}
       end
 
     """
@@ -35,8 +35,8 @@ defmodule Membrane.Core.Child.PadsSpecs do
   Returns AST inserted into element's or bin's module defining a pad
   """
   @spec def_pad(
-          Pad.name_t(),
-          Pad.direction_t(),
+          Pad.name(),
+          Pad.direction(),
           Macro.t(),
           :filter | :endpoint | :source | :sink | :bin
         ) :: Macro.t()
@@ -98,7 +98,7 @@ defmodule Membrane.Core.Child.PadsSpecs do
 
       unless Module.defines?(__MODULE__, {:membrane_stream_format_match?, 2}) do
         @doc false
-        @spec membrane_stream_format_match?(Membrane.Pad.name_t(), Membrane.StreamFormat.t()) ::
+        @spec membrane_stream_format_match?(Membrane.Pad.name(), Membrane.StreamFormat.t()) ::
                 boolean()
       end
 
@@ -132,7 +132,7 @@ defmodule Membrane.Core.Child.PadsSpecs do
 
     quote do
       @doc false
-      @spec membrane_pads() :: [{unquote(Pad).name_t(), unquote(Pad).description_t()}]
+      @spec membrane_pads() :: [{unquote(Pad).name(), unquote(Pad).description()}]
       def membrane_pads() do
         unquote(pads |> Macro.escape())
       end
@@ -140,7 +140,7 @@ defmodule Membrane.Core.Child.PadsSpecs do
   end
 
   @spec validate_pads!(
-          pads :: [{Pad.name_t(), Pad.description_t()}],
+          pads :: [{Pad.name(), Pad.description()}],
           env :: Macro.Env.t()
         ) :: :ok
   defp validate_pads!(pads, env) do
@@ -153,11 +153,11 @@ defmodule Membrane.Core.Child.PadsSpecs do
   end
 
   @spec parse_pad_specs!(
-          specs :: Pad.spec_t(),
-          direction :: Pad.direction_t(),
+          specs :: Pad.spec(),
+          direction :: Pad.direction(),
           :filter | :endpoint | :source | :sink | :bin,
           declaration_env :: Macro.Env.t()
-        ) :: {Pad.name_t(), Pad.description_t()}
+        ) :: {Pad.name(), Pad.description()}
   def parse_pad_specs!(specs, direction, component, env) do
     with {:ok, specs} <- parse_pad_specs(specs, direction, component) do
       specs
@@ -174,11 +174,11 @@ defmodule Membrane.Core.Child.PadsSpecs do
   end
 
   @spec parse_pad_specs(
-          Pad.spec_t(),
-          Pad.direction_t(),
+          Pad.spec(),
+          Pad.direction(),
           :filter | :endpoint | :source | :sink | :bin
         ) ::
-          {Pad.name_t(), Pad.description_t()} | {:error, reason :: any}
+          {Pad.name(), Pad.description()} | {:error, reason :: any}
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def parse_pad_specs(spec, direction, component) do
     withl spec: {name, config} when Pad.is_pad_name(name) and is_list(config) <- spec,
@@ -229,7 +229,7 @@ defmodule Membrane.Core.Child.PadsSpecs do
   @doc """
   Generates docs describing pads based on pads specification.
   """
-  @spec generate_docs_from_pads_specs([{Pad.name_t(), Pad.description_t()}]) :: Macro.t()
+  @spec generate_docs_from_pads_specs([{Pad.name(), Pad.description()}]) :: Macro.t()
   def generate_docs_from_pads_specs([]) do
     quote do
       """

--- a/lib/membrane/core/component.ex
+++ b/lib/membrane/core/component.ex
@@ -1,30 +1,30 @@
 defmodule Membrane.Core.Component do
   @moduledoc false
 
-  @type state_t ::
+  @type state ::
           Membrane.Core.Pipeline.State.t()
           | Membrane.Core.Bin.State.t()
           | Membrane.Core.Element.State.t()
 
-  @type callback_context_optional_fields_t ::
-          Membrane.Core.Element.CallbackContext.optional_fields_t()
-          | Membrane.Core.Bin.CallbackContext.optional_fields_t()
-          | Membrane.Core.Pipeline.CallbackContext.optional_fields_t()
+  @type callback_context_optional_fields ::
+          Membrane.Core.Element.CallbackContext.optional_fields()
+          | Membrane.Core.Bin.CallbackContext.optional_fields()
+          | Membrane.Core.Pipeline.CallbackContext.optional_fields()
 
-  @type callback_context_t ::
+  @type callback_context ::
           Membrane.Element.CallbackContext.t()
           | Membrane.Bin.CallbackContext.t()
           | Membrane.Pipeline.CallbackContext.t()
 
-  @spec action_handler(state_t) :: module
+  @spec action_handler(state) :: module
   [Pipeline, Bin, Element]
   |> Enum.map(fn component ->
     def action_handler(%unquote(Module.concat([Membrane.Core, component, State])){}),
       do: unquote(Module.concat([Membrane.Core, component, ActionHandler]))
   end)
 
-  @spec context_from_state(state_t(), callback_context_optional_fields_t()) ::
-          callback_context_t()
+  @spec context_from_state(state(), callback_context_optional_fields()) ::
+          callback_context()
   def context_from_state(state, args \\ []) do
     alias Membrane.Core.{Bin, Element, Pipeline}
 
@@ -38,21 +38,21 @@ defmodule Membrane.Core.Component do
     callback_context_module.from_state(state, args)
   end
 
-  @spec is_pipeline?(state_t) :: boolean()
+  @spec is_pipeline?(state) :: boolean()
   def is_pipeline?(%Membrane.Core.Pipeline.State{}), do: true
   def is_pipeline?(_state), do: false
 
-  @spec is_element?(state_t) :: boolean()
+  @spec is_element?(state) :: boolean()
   def is_element?(%Membrane.Core.Element.State{}), do: true
   def is_element?(_state), do: false
 
-  @spec is_bin?(state_t) :: boolean()
+  @spec is_bin?(state) :: boolean()
   def is_bin?(%Membrane.Core.Bin.State{}), do: true
   def is_bin?(_state), do: false
 
-  @spec is_child?(state_t) :: boolean()
+  @spec is_child?(state) :: boolean()
   def is_child?(state), do: is_element?(state) or is_bin?(state)
 
-  @spec is_parent?(state_t) :: boolean()
+  @spec is_parent?(state) :: boolean()
   def is_parent?(state), do: is_pipeline?(state) or is_bin?(state)
 end

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -36,15 +36,15 @@ defmodule Membrane.Core.Element do
   require Membrane.Core.Telemetry, as: Telemetry
   require Membrane.Logger
 
-  @type options_t :: %{
+  @type options :: %{
           module: module,
-          name: Membrane.Element.name_t(),
+          name: Membrane.Element.name(),
           node: node | nil,
-          user_options: Membrane.Element.options_t(),
+          user_options: Membrane.Element.options(),
           sync: Sync.t(),
           parent: pid,
           parent_clock: Clock.t(),
-          parent_path: Membrane.ComponentPath.path_t(),
+          parent_path: Membrane.ComponentPath.path(),
           log_metadata: Logger.metadata(),
           subprocess_supervisor: pid(),
           parent_supervisor: pid()
@@ -56,14 +56,14 @@ defmodule Membrane.Core.Element do
 
   Calls `GenServer.start_link/3` underneath.
   """
-  @spec start_link(options_t) :: GenServer.on_start()
+  @spec start_link(options) :: GenServer.on_start()
   def start_link(options),
     do: do_start(:start_link, options)
 
   @doc """
   Works similarly to `start_link/3`, but does not link to the current process.
   """
-  @spec start(options_t) :: GenServer.on_start()
+  @spec start(options) :: GenServer.on_start()
   def start(options),
     do: do_start(:start, options)
 

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -274,7 +274,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     end
   end
 
-  @spec send_buffer(Pad.ref_t(), [Buffer.t()] | Buffer.t(), State.t()) :: State.t()
+  @spec send_buffer(Pad.ref(), [Buffer.t()] | Buffer.t(), State.t()) :: State.t()
   defp send_buffer(_pad_ref, [], state) do
     state
   end
@@ -330,7 +330,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     raise ElementError, "Tried to send an invalid buffer #{inspect(invalid_value)}"
   end
 
-  @spec send_stream_format(Pad.ref_t(), StreamFormat.t(), State.t()) :: State.t()
+  @spec send_stream_format(Pad.ref(), StreamFormat.t(), State.t()) :: State.t()
   def send_stream_format(pad_ref, stream_format, state) do
     Membrane.Logger.debug("""
     Sending stream format through pad #{inspect(pad_ref)}
@@ -367,8 +367,8 @@ defmodule Membrane.Core.Element.ActionHandler do
   end
 
   @spec supply_demand(
-          Pad.ref_t(),
-          Action.demand_size_t(),
+          Pad.ref(),
+          Action.demand_size(),
           State.t()
         ) :: State.t()
   defp supply_demand(pad_ref, 0, state) do
@@ -400,7 +400,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     end
   end
 
-  @spec handle_redemand(Pad.ref_t(), State.t()) :: State.t()
+  @spec handle_redemand(Pad.ref(), State.t()) :: State.t()
   defp handle_redemand(pad_ref, %{type: type} = state)
        when type in [:source, :filter, :endpoint] do
     with %{direction: :output, flow_control: :manual} <-
@@ -420,7 +420,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     end
   end
 
-  @spec send_event(Pad.ref_t(), Event.t(), State.t()) :: State.t()
+  @spec send_event(Pad.ref(), Event.t(), State.t()) :: State.t()
   defp send_event(pad_ref, event, state) do
     Membrane.Logger.debug_verbose("""
     Sending event through pad #{inspect(pad_ref)}
@@ -438,7 +438,7 @@ defmodule Membrane.Core.Element.ActionHandler do
     end
   end
 
-  @spec handle_event(Pad.ref_t(), Event.t(), State.t()) :: State.t()
+  @spec handle_event(Pad.ref(), Event.t(), State.t()) :: State.t()
   defp handle_event(pad_ref, %Events.EndOfStream{}, state) do
     with %{direction: :output, end_of_stream?: false} <- PadModel.get_data!(state, pad_ref) do
       state = PadController.remove_pad_associations(pad_ref, state)

--- a/lib/membrane/core/element/buffer_controller.ex
+++ b/lib/membrane/core/element/buffer_controller.ex
@@ -30,7 +30,7 @@ defmodule Membrane.Core.Element.BufferController do
   callback. Also calls `Membrane.Core.Element.DemandHandler.supply_demand/2`
   to check if there are any unsupplied demands.
   """
-  @spec handle_buffer(Pad.ref_t(), [Buffer.t()] | Buffer.t(), State.t()) :: State.t()
+  @spec handle_buffer(Pad.ref(), [Buffer.t()] | Buffer.t(), State.t()) :: State.t()
   def handle_buffer(pad_ref, buffers, state) do
     withl pad: {:ok, data} <- PadModel.get_data(state, pad_ref),
           playback: %State{playback: :playing} <- state do
@@ -54,7 +54,7 @@ defmodule Membrane.Core.Element.BufferController do
     end
   end
 
-  @spec do_handle_buffer(Pad.ref_t(), PadModel.pad_data_t(), [Buffer.t()] | Buffer.t(), State.t()) ::
+  @spec do_handle_buffer(Pad.ref(), PadModel.pad_data(), [Buffer.t()] | Buffer.t(), State.t()) ::
           State.t()
   defp do_handle_buffer(pad_ref, %{flow_control: :auto} = data, buffers, state) do
     %{demand: demand, demand_unit: demand_unit} = data
@@ -86,7 +86,7 @@ defmodule Membrane.Core.Element.BufferController do
   Executes `handle_buffers_batch` callback.
   """
   @spec exec_buffer_callback(
-          Pad.ref_t(),
+          Pad.ref(),
           [Buffer.t()] | Buffer.t(),
           State.t()
         ) :: State.t()

--- a/lib/membrane/core/element/callback_context.ex
+++ b/lib/membrane/core/element/callback_context.ex
@@ -1,12 +1,12 @@
 defmodule Membrane.Core.Element.CallbackContext do
   @moduledoc false
 
-  @type optional_fields_t ::
+  @type optional_fields ::
           [incoming_demand: non_neg_integer()]
           | [pad_options: map()]
           | [old_stream_format: Membrane.StreamFormat.t()]
 
-  @spec from_state(Membrane.Core.Element.State.t(), optional_fields_t()) ::
+  @spec from_state(Membrane.Core.Element.State.t(), optional_fields()) ::
           Membrane.Element.CallbackContext.t()
   def from_state(state, optional_fields \\ []) do
     Map.new(optional_fields)

--- a/lib/membrane/core/element/demand_controller.ex
+++ b/lib/membrane/core/element/demand_controller.ex
@@ -16,7 +16,7 @@ defmodule Membrane.Core.Element.DemandController do
   @doc """
   Handles demand coming on an output pad. Updates demand value and executes `handle_demand` callback.
   """
-  @spec handle_demand(Pad.ref_t(), non_neg_integer, State.t()) :: State.t()
+  @spec handle_demand(Pad.ref(), non_neg_integer, State.t()) :: State.t()
   def handle_demand(pad_ref, size, state) do
     withl pad: {:ok, data} <- PadModel.get_data(state, pad_ref),
           playback: %State{playback: :playing} <- state do
@@ -81,7 +81,7 @@ defmodule Membrane.Core.Element.DemandController do
   Also, the `demand_decrease` argument can be passed, decreasing the size of the
   demand on the input pad before proceeding to the rest of the function logic.
   """
-  @spec send_auto_demand_if_needed(Pad.ref_t(), integer, State.t()) :: State.t()
+  @spec send_auto_demand_if_needed(Pad.ref(), integer, State.t()) :: State.t()
   def send_auto_demand_if_needed(pad_ref, demand_decrease \\ 0, state) do
     data = PadModel.get_data!(state, pad_ref)
 

--- a/lib/membrane/core/element/demand_handler.ex
+++ b/lib/membrane/core/element/demand_handler.ex
@@ -29,7 +29,7 @@ defmodule Membrane.Core.Element.DemandHandler do
     * If element isn't supplying demand at the moment and there's some unsupplied demand on the given
       output, `handle_demand` is invoked right away, so that the demand can be synchronously supplied.
   """
-  @spec handle_redemand(Pad.ref_t(), State.t()) :: State.t()
+  @spec handle_redemand(Pad.ref(), State.t()) :: State.t()
   def handle_redemand(pad_ref, %State{supplying_demand?: true} = state) do
     Map.update!(state, :delayed_demands, &MapSet.put(&1, {pad_ref, :redemand}))
   end
@@ -55,7 +55,7 @@ defmodule Membrane.Core.Element.DemandHandler do
   before proceeding to supplying it.
   """
   @spec supply_demand(
-          Pad.ref_t(),
+          Pad.ref(),
           size :: non_neg_integer | (non_neg_integer() -> non_neg_integer()),
           State.t()
         ) :: State.t()
@@ -64,7 +64,7 @@ defmodule Membrane.Core.Element.DemandHandler do
     supply_demand(pad_ref, state)
   end
 
-  @spec supply_demand(Pad.ref_t(), State.t()) :: State.t()
+  @spec supply_demand(Pad.ref(), State.t()) :: State.t()
   def supply_demand(pad_ref, %State{supplying_demand?: true} = state) do
     Map.update!(state, :delayed_demands, &MapSet.put(&1, {pad_ref, :supply}))
   end
@@ -98,8 +98,8 @@ defmodule Membrane.Core.Element.DemandHandler do
   overflow if the toilet is enabled.
   """
   @spec handle_outgoing_buffers(
-          Pad.ref_t(),
-          PadModel.pad_data_t(),
+          Pad.ref(),
+          PadModel.pad_data(),
           [Buffer.t()],
           State.t()
         ) :: State.t()
@@ -178,8 +178,8 @@ defmodule Membrane.Core.Element.DemandHandler do
   end
 
   @spec handle_input_queue_output(
-          Pad.ref_t(),
-          [InputQueue.output_value_t()],
+          Pad.ref(),
+          [InputQueue.output_value()],
           State.t()
         ) :: State.t()
   defp handle_input_queue_output(pad_ref, data, state) do
@@ -189,8 +189,8 @@ defmodule Membrane.Core.Element.DemandHandler do
   end
 
   @spec do_handle_input_queue_output(
-          Pad.ref_t(),
-          InputQueue.output_value_t(),
+          Pad.ref(),
+          InputQueue.output_value(),
           State.t()
         ) :: State.t()
   defp do_handle_input_queue_output(pad_ref, {:event, e}, state),

--- a/lib/membrane/core/element/event_controller.ex
+++ b/lib/membrane/core/element/event_controller.ex
@@ -23,7 +23,7 @@ defmodule Membrane.Core.Element.EventController do
   require Membrane.Core.Telemetry
   require Membrane.Logger
 
-  @spec handle_start_of_stream(Pad.ref_t(), State.t()) :: State.t()
+  @spec handle_start_of_stream(Pad.ref(), State.t()) :: State.t()
   def handle_start_of_stream(pad_ref, state) do
     handle_event(pad_ref, %Events.StartOfStream{}, state)
   end
@@ -33,7 +33,7 @@ defmodule Membrane.Core.Element.EventController do
   Extra checks and tasks required by special events such as `:start_of_stream`
   or `:end_of_stream` are performed.
   """
-  @spec handle_event(Pad.ref_t(), Event.t(), State.t()) :: State.t()
+  @spec handle_event(Pad.ref(), Event.t(), State.t()) :: State.t()
   def handle_event(pad_ref, event, state) do
     withl pad: {:ok, data} <- PadModel.get_data(state, pad_ref),
           playback: %State{playback: :playing} <- state do
@@ -59,7 +59,7 @@ defmodule Membrane.Core.Element.EventController do
     end
   end
 
-  @spec exec_handle_event(Pad.ref_t(), Event.t(), params :: map, State.t()) :: State.t()
+  @spec exec_handle_event(Pad.ref(), Event.t(), params :: map, State.t()) :: State.t()
   def exec_handle_event(pad_ref, event, params \\ %{}, state) do
     case handle_special_event(pad_ref, event, state) do
       {:handle, state} ->
@@ -71,7 +71,7 @@ defmodule Membrane.Core.Element.EventController do
     end
   end
 
-  @spec do_exec_handle_event(Pad.ref_t(), Event.t(), params :: map, State.t()) :: State.t()
+  @spec do_exec_handle_event(Pad.ref(), Event.t(), params :: map, State.t()) :: State.t()
   defp do_exec_handle_event(pad_ref, %event_type{} = event, params, state)
        when event_type in [Events.StartOfStream, Events.EndOfStream] do
     data = PadModel.get_data!(state, pad_ref)
@@ -123,7 +123,7 @@ defmodule Membrane.Core.Element.EventController do
     :ok
   end
 
-  @spec handle_special_event(Pad.ref_t(), Event.t(), State.t()) ::
+  @spec handle_special_event(Pad.ref(), Event.t(), State.t()) ::
           {:handle | :ignore, State.t()}
   defp handle_special_event(pad_ref, %Events.StartOfStream{}, state) do
     Membrane.Logger.debug("received start of stream")

--- a/lib/membrane/core/element/input_queue.ex
+++ b/lib/membrane/core/element/input_queue.ex
@@ -21,9 +21,9 @@ defmodule Membrane.Core.Element.InputQueue do
 
   @non_buf_types [:event, :stream_format]
 
-  @type output_value_t ::
+  @type output_value ::
           {:event | :stream_format, any} | {:buffers, list, pos_integer, pos_integer}
-  @type output_t :: {:empty | :value, [output_value_t]}
+  @type output :: {:empty | :value, [output_value]}
 
   @type t :: %__MODULE__{
           q: @qe.t(),
@@ -57,10 +57,10 @@ defmodule Membrane.Core.Element.InputQueue do
   def default_min_demand_factor, do: 0.25
 
   @spec init(%{
-          inbound_demand_unit: Buffer.Metric.unit_t(),
-          outbound_demand_unit: Buffer.Metric.unit_t(),
+          inbound_demand_unit: Buffer.Metric.unit(),
+          outbound_demand_unit: Buffer.Metric.unit(),
           demand_pid: pid(),
-          demand_pad: Pad.ref_t(),
+          demand_pad: Pad.ref(),
           log_tag: String.t(),
           toilet?: boolean(),
           target_size: pos_integer() | nil,
@@ -158,7 +158,7 @@ defmodule Membrane.Core.Element.InputQueue do
     }
   end
 
-  @spec take_and_demand(t(), non_neg_integer(), pid(), Pad.ref_t()) :: {output_t(), t()}
+  @spec take_and_demand(t(), non_neg_integer(), pid(), Pad.ref()) :: {output(), t()}
   def take_and_demand(
         %__MODULE__{} = input_queue,
         count,
@@ -292,7 +292,7 @@ defmodule Membrane.Core.Element.InputQueue do
     end
   end
 
-  @spec send_demands(t(), pid(), Pad.ref_t()) :: t()
+  @spec send_demands(t(), pid(), Pad.ref()) :: t()
   defp send_demands(
          %__MODULE__{
            toilet?: false,

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -17,7 +17,7 @@ defmodule Membrane.Core.Element.LifecycleController do
   @doc """
   Performs initialization tasks and executes `handle_init` callback.
   """
-  @spec handle_init(Element.options_t(), State.t()) :: State.t()
+  @spec handle_init(Element.options(), State.t()) :: State.t()
   def handle_init(options, %State{module: module} = state) do
     Membrane.Logger.debug(
       "Initializing element: #{inspect(module)}, options: #{inspect(options)}"

--- a/lib/membrane/core/element/pad_controller.ex
+++ b/lib/membrane/core/element/pad_controller.ex
@@ -26,33 +26,33 @@ defmodule Membrane.Core.Element.PadController do
   require Membrane.Logger
   require Membrane.Pad
 
-  @type link_call_props_t ::
+  @type link_call_props ::
           %{
             initiator: :parent,
             stream_format_validation_params:
-              StreamFormatController.stream_format_validation_params_t()
+              StreamFormatController.stream_format_validation_params()
           }
           | %{
               initiator: :sibling,
-              other_info: PadModel.pad_info_t() | nil,
+              other_info: PadModel.pad_info() | nil,
               link_metadata: %{toilet: Toilet.t() | nil},
               stream_format_validation_params:
-                StreamFormatController.stream_format_validation_params_t()
+                StreamFormatController.stream_format_validation_params()
             }
 
-  @type link_call_reply_props_t ::
-          {Endpoint.t(), PadModel.pad_info_t(), %{toilet: Toilet.t() | nil}}
+  @type link_call_reply_props ::
+          {Endpoint.t(), PadModel.pad_info(), %{toilet: Toilet.t() | nil}}
 
-  @type link_call_reply_t ::
-          :ok | {:ok, link_call_reply_props_t} | {:error, {:neighbor_dead, reason :: any}}
+  @type link_call_reply ::
+          :ok | {:ok, link_call_reply_props} | {:error, {:neighbor_dead, reason :: any}}
 
   @default_auto_demand_size_factor 4000
 
   @doc """
   Verifies linked pad, initializes it's data.
   """
-  @spec handle_link(Pad.direction_t(), Endpoint.t(), Endpoint.t(), link_call_props_t, State.t()) ::
-          {link_call_reply_t, State.t()}
+  @spec handle_link(Pad.direction(), Endpoint.t(), Endpoint.t(), link_call_props, State.t()) ::
+          {link_call_reply, State.t()}
   def handle_link(direction, endpoint, other_endpoint, link_props, state) do
     Membrane.Logger.debug(
       "Element handle link on pad #{inspect(endpoint.pad_ref)} with pad #{inspect(other_endpoint.pad_ref)} of child #{inspect(other_endpoint.child)}"
@@ -190,7 +190,7 @@ defmodule Membrane.Core.Element.PadController do
   Executes `handle_pad_removed` callback if the pad was dynamic.
   Note: it also flushes all buffers from PlaybackBuffer.
   """
-  @spec handle_unlink(Pad.ref_t(), State.t()) :: State.t()
+  @spec handle_unlink(Pad.ref(), State.t()) :: State.t()
   def handle_unlink(pad_ref, state) do
     with {:ok, %{availability: :on_request}} <- PadModel.get_data(state, pad_ref) do
       state = generate_eos_if_needed(pad_ref, state)
@@ -385,7 +385,7 @@ defmodule Membrane.Core.Element.PadController do
   Generates end of stream on the given input pad if it hasn't been generated yet
   and playback is `playing`.
   """
-  @spec generate_eos_if_needed(Pad.ref_t(), State.t()) :: State.t()
+  @spec generate_eos_if_needed(Pad.ref(), State.t()) :: State.t()
   def generate_eos_if_needed(pad_ref, state) do
     %{direction: direction, end_of_stream?: eos?} = PadModel.get_data!(state, pad_ref)
 
@@ -399,7 +399,7 @@ defmodule Membrane.Core.Element.PadController do
   @doc """
   Removes all associations between the given pad and any other_endpoint pads.
   """
-  @spec remove_pad_associations(Pad.ref_t(), State.t()) :: State.t()
+  @spec remove_pad_associations(Pad.ref(), State.t()) :: State.t()
   def remove_pad_associations(pad_ref, state) do
     case PadModel.get_data!(state, pad_ref) do
       %{flow_control: :auto} = pad_data ->
@@ -424,7 +424,7 @@ defmodule Membrane.Core.Element.PadController do
     end
   end
 
-  @spec maybe_handle_pad_added(Pad.ref_t(), State.t()) :: State.t()
+  @spec maybe_handle_pad_added(Pad.ref(), State.t()) :: State.t()
   defp maybe_handle_pad_added(ref, state) do
     %{options: pad_opts, availability: availability} = PadModel.get_data!(state, ref)
 
@@ -443,7 +443,7 @@ defmodule Membrane.Core.Element.PadController do
     end
   end
 
-  @spec maybe_handle_pad_removed(Pad.ref_t(), State.t()) :: State.t()
+  @spec maybe_handle_pad_removed(Pad.ref(), State.t()) :: State.t()
   defp maybe_handle_pad_removed(ref, state) do
     %{availability: availability} = PadModel.get_data!(state, ref)
 

--- a/lib/membrane/core/element/state.ex
+++ b/lib/membrane/core/element/state.ex
@@ -15,18 +15,18 @@ defmodule Membrane.Core.Element.State do
 
   @type t :: %__MODULE__{
           module: module,
-          type: Element.type_t(),
-          name: Element.name_t(),
-          internal_state: Element.state_t() | nil,
-          pads_info: PadModel.pads_info_t() | nil,
-          pads_data: PadModel.pads_data_t() | nil,
+          type: Element.type(),
+          name: Element.name(),
+          internal_state: Element.state() | nil,
+          pads_info: PadModel.pads_info() | nil,
+          pads_data: PadModel.pads_data() | nil,
           parent_pid: pid,
           supplying_demand?: boolean(),
-          delayed_demands: MapSet.t({Pad.ref_t(), :supply | :redemand}),
+          delayed_demands: MapSet.t({Pad.ref(), :supply | :redemand}),
           synchronization: %{
-            timers: %{Timer.id_t() => Timer.t()},
+            timers: %{Timer.id() => Timer.t()},
             parent_clock: Clock.t(),
-            latency: Membrane.Time.non_neg_t(),
+            latency: Membrane.Time.non_neg(),
             stream_sync: Sync.t(),
             clock: Clock.t() | nil
           },
@@ -65,7 +65,7 @@ defmodule Membrane.Core.Element.State do
   """
   @spec new(%{
           module: module,
-          name: Element.name_t(),
+          name: Element.name(),
           parent_clock: Clock.t(),
           sync: Sync.t(),
           parent: pid,

--- a/lib/membrane/core/element/stream_format_controller.ex
+++ b/lib/membrane/core/element/stream_format_controller.ex
@@ -14,13 +14,13 @@ defmodule Membrane.Core.Element.StreamFormatController do
   require Membrane.Core.Telemetry
   require Membrane.Logger
 
-  @type stream_format_validation_param_t() :: {module(), Pad.name_t()}
-  @type stream_format_validation_params_t() :: [stream_format_validation_param_t()]
+  @type stream_format_validation_param() :: {module(), Pad.name()}
+  @type stream_format_validation_params() :: [stream_format_validation_param()]
 
   @doc """
   Handles incoming stream format: either stores it in InputQueue, or executes element callback.
   """
-  @spec handle_stream_format(Pad.ref_t(), StreamFormat.t(), State.t()) :: State.t()
+  @spec handle_stream_format(Pad.ref(), StreamFormat.t(), State.t()) :: State.t()
   def handle_stream_format(pad_ref, stream_format, state) do
     withl pad: {:ok, data} <- PadModel.get_data(state, pad_ref),
           playback: %State{playback: :playing} <- state do
@@ -49,7 +49,7 @@ defmodule Membrane.Core.Element.StreamFormatController do
     end
   end
 
-  @spec exec_handle_stream_format(Pad.ref_t(), StreamFormat.t(), params :: map, State.t()) ::
+  @spec exec_handle_stream_format(Pad.ref(), StreamFormat.t(), params :: map, State.t()) ::
           State.t()
   def exec_handle_stream_format(pad_ref, stream_format, params \\ %{}, state) do
     %{
@@ -80,8 +80,8 @@ defmodule Membrane.Core.Element.StreamFormatController do
   end
 
   @spec validate_stream_format!(
-          Pad.direction_t(),
-          stream_format_validation_params_t(),
+          Pad.direction(),
+          stream_format_validation_params(),
           StreamFormat.t()
         ) :: :ok
   def validate_stream_format!(direction, params, stream_format) do

--- a/lib/membrane/core/element/toilet.ex
+++ b/lib/membrane/core/element/toilet.ex
@@ -83,7 +83,7 @@ defmodule Membrane.Core.Element.Toilet do
 
   @spec new(
           pos_integer() | nil,
-          Membrane.Buffer.Metric.unit_t(),
+          Membrane.Buffer.Metric.unit(),
           Process.dest(),
           pos_integer()
         ) :: t
@@ -162,7 +162,7 @@ defmodule Membrane.Core.Element.Toilet do
     when storing data from output working in push mode. It means that some element in the pipeline
     processes the stream too slow or doesn't process it at all.
     To have control over amount of buffers being produced, consider using output in :auto or :manual
-    flow control mode. (see `Membrane.Pad.flow_control_t`).
+    flow control mode. (see `Membrane.Pad.flow_control`).
     You can also try changing the `toilet_capacity` in `Membrane.ChildrenSpec.via_in/3`.
     """)
 

--- a/lib/membrane/core/filter_aggregator/context.ex
+++ b/lib/membrane/core/filter_aggregator/context.ex
@@ -10,11 +10,11 @@ defmodule Membrane.Core.FilterAggregator.Context do
   @typedoc """
   Collection of states for encapsuled elements as kept in `Membrane.FilterAggregator` element
   """
-  @type states :: [{Element.name_t(), module(), t(), Element.state_t()}]
+  @type states :: [{Element.name(), module(), t(), Element.state()}]
 
   @type action :: Element.Action.t() | Membrane.Core.FilterAggregator.InternalAction.t()
 
-  @spec build_context!(Element.name_t(), module(), t()) :: t()
+  @spec build_context!(Element.name(), module(), t()) :: t()
   def build_context!(name, module, agg_ctx) do
     pad_descriptions = module.membrane_pads()
     pads = pad_descriptions |> MapSet.new(fn {k, _v} -> k end)

--- a/lib/membrane/core/lifecycle_controller.ex
+++ b/lib/membrane/core/lifecycle_controller.ex
@@ -7,10 +7,10 @@ defmodule Membrane.Core.LifecycleController do
   require Membrane.Core.Message
   require Membrane.Logger
 
-  @type setup_operation_t :: :incomplete | :complete
+  @type setup_operation :: :incomplete | :complete
 
-  @spec handle_setup_operation(setup_operation_t(), Component.state_t()) ::
-          Component.state_t()
+  @spec handle_setup_operation(setup_operation(), Component.state()) ::
+          Component.state()
   def handle_setup_operation(operation, state) do
     :ok = assert_operation_allowed!(operation, state.setup_incomplete?)
 
@@ -24,7 +24,7 @@ defmodule Membrane.Core.LifecycleController do
     end
   end
 
-  @spec complete_setup(Component.state_t()) :: Component.state_t()
+  @spec complete_setup(Component.state()) :: Component.state()
   def complete_setup(state) do
     state = %{state | initialized?: true, setup_incomplete?: false}
     Membrane.Logger.debug("Component initialized")
@@ -39,7 +39,7 @@ defmodule Membrane.Core.LifecycleController do
     end
   end
 
-  @spec assert_operation_allowed!(setup_operation_t(), boolean()) :: :ok | no_return()
+  @spec assert_operation_allowed!(setup_operation(), boolean()) :: :ok | no_return()
   defp assert_operation_allowed!(:incomplete, true) do
     raise SetupError, """
     Action {:setup, :incomplete} was returned more than once

--- a/lib/membrane/core/message.ex
+++ b/lib/membrane/core/message.ex
@@ -9,10 +9,10 @@ defmodule Membrane.Core.Message do
 
   Record.defrecord(:message, __MODULE__, type: nil, args: [], opts: [])
 
-  @type t :: {__MODULE__, type_t, args_t, opts_t}
-  @type type_t :: atom
-  @type args_t :: list | any
-  @type opts_t :: Keyword.t()
+  @type t :: {__MODULE__, type, args, opts}
+  @type type :: atom
+  @type args :: list | any
+  @type opts :: Keyword.t()
 
   defmacro new(type, args \\ [], opts \\ []) do
     quote do
@@ -20,17 +20,17 @@ defmodule Membrane.Core.Message do
     end
   end
 
-  @spec send(pid, type_t, args_t, opts_t) :: t
+  @spec send(pid, type, args, opts) :: t
   def send(pid, type, args \\ [], opts \\ []) do
     Kernel.send(pid, message(type: type, args: args, opts: opts))
   end
 
-  @spec self(type_t, args_t, opts_t) :: t
+  @spec self(type, args, opts) :: t
   def self(type, args \\ [], opts \\ []) do
     __MODULE__.send(self(), type, args, opts)
   end
 
-  @spec call(GenServer.server(), type_t, args_t, opts_t, timeout()) ::
+  @spec call(GenServer.server(), type, args, opts, timeout()) ::
           term() | {:error, {:call_failure, any}}
   def call(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
     try do
@@ -41,15 +41,15 @@ defmodule Membrane.Core.Message do
     end
   end
 
-  @spec call!(GenServer.server(), type_t, args_t, opts_t, timeout()) :: term()
+  @spec call!(GenServer.server(), type, args, opts, timeout()) :: term()
   def call!(pid, type, args \\ [], opts \\ [], timeout \\ 5000) do
     GenServer.call(pid, message(type: type, args: args, opts: opts), timeout)
   end
 
-  @spec for_pad(t()) :: Pad.ref_t()
+  @spec for_pad(t()) :: Pad.ref()
   def for_pad(message(opts: opts)), do: Keyword.get(opts, :for_pad)
 
-  @spec set_for_pad(t(), Pad.ref_t()) :: t()
+  @spec set_for_pad(t(), Pad.ref()) :: t()
   def set_for_pad(message(opts: opts) = msg, pad),
     do: message(msg, opts: Keyword.put(opts, :for_pad, pad))
 end

--- a/lib/membrane/core/observability.ex
+++ b/lib/membrane/core/observability.ex
@@ -10,9 +10,9 @@ defmodule Membrane.Core.Observability do
                                         )
 
   @type config :: %{
-          optional(:parent_path) => ComponentPath.path_t(),
+          optional(:parent_path) => ComponentPath.path(),
           optional(:log_metadata) => Logger.metadata(),
-          name: Membrane.Child.name_t(),
+          name: Membrane.Child.name(),
           component_type: :element | :bin | :pipeline,
           pid: pid()
         }
@@ -71,7 +71,7 @@ defmodule Membrane.Core.Observability do
   Can be optionally turned on by setting `unsafely_name_processes_for_observer: :links` in
   config.exs.
   """
-  @spec setup_link(Membrane.Pad.ref_t(), metadata) :: metadata
+  @spec setup_link(Membrane.Pad.ref(), metadata) :: metadata
         when metadata: %{optional(:process_to_link) => pid()}
   if :links in @unsafely_name_processes_for_observer do
     def setup_link(pad_ref, observability_metadata \\ %{}) do

--- a/lib/membrane/core/options_specs.ex
+++ b/lib/membrane/core/options_specs.ex
@@ -55,7 +55,7 @@ defmodule Membrane.Core.OptionsSpecs do
     end
   end
 
-  @spec def_pad_options(Pad.name_t(), nil | Keyword.t()) :: {Macro.t(), Macro.t()}
+  @spec def_pad_options(Pad.name(), nil | Keyword.t()) :: {Macro.t(), Macro.t()}
   def def_pad_options(_pad_name, nil) do
     no_code =
       quote do
@@ -66,7 +66,7 @@ defmodule Membrane.Core.OptionsSpecs do
 
   def def_pad_options(pad_name, options) do
     {opt_typespecs, escaped_opts} = parse_opts(options)
-    pad_opts_type_name = "#{pad_name}_pad_opts_t" |> String.to_atom()
+    pad_opts_type_name = "#{pad_name}_pad_opts" |> String.to_atom()
 
     type_definiton =
       quote do

--- a/lib/membrane/core/parent.ex
+++ b/lib/membrane/core/parent.ex
@@ -1,5 +1,5 @@
 defmodule Membrane.Core.Parent do
   @moduledoc false
 
-  @type state_t :: Membrane.Core.Bin.State.t() | Membrane.Core.Pipeline.State.t()
+  @type state :: Membrane.Core.Bin.State.t() | Membrane.Core.Pipeline.State.t()
 end

--- a/lib/membrane/core/parent/child_entry_parser.ex
+++ b/lib/membrane/core/parent/child_entry_parser.ex
@@ -3,15 +3,15 @@ defmodule Membrane.Core.Parent.ChildEntryParser do
 
   alias Membrane.{ChildEntry, ChildrenSpec, ParentError}
 
-  @type raw_child_entry_t :: %ChildEntry{
-          name: Membrane.Child.name_t(),
+  @type raw_child_entry :: %ChildEntry{
+          name: Membrane.Child.name(),
           module: module,
           options: struct | nil,
           component_type: :element | :bin
         }
 
-  @spec parse([ChildrenSpec.Builder.child_spec_t()]) ::
-          [raw_child_entry_t] | no_return
+  @spec parse([ChildrenSpec.Builder.child_spec()]) ::
+          [raw_child_entry] | no_return
   def parse(children_spec) do
     Enum.map(children_spec, &parse_child/1)
   end

--- a/lib/membrane/core/parent/child_life_controller/crash_group_utils.ex
+++ b/lib/membrane/core/parent/child_life_controller/crash_group_utils.ex
@@ -7,8 +7,8 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupUtils do
   alias Membrane.Core.Pipeline
 
   @spec add_crash_group(
-          {Membrane.Child.group_t(), Membrane.CrashGroup.mode_t()},
-          [Membrane.Child.name_t()],
+          {Membrane.Child.group(), Membrane.CrashGroup.mode()},
+          [Membrane.Child.name()],
           [pid()],
           Pipeline.State.t()
         ) :: Pipeline.State.t()
@@ -36,7 +36,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupUtils do
     end)
   end
 
-  @spec remove_crash_group_if_empty(Pipeline.State.t(), CrashGroup.name_t()) ::
+  @spec remove_crash_group_if_empty(Pipeline.State.t(), CrashGroup.name()) ::
           {:removed | :not_removed, Pipeline.State.t()}
   def remove_crash_group_if_empty(state, group_name) do
     %CrashGroup{alive_members_pids: alive_members_pids} = state.crash_groups[group_name]
@@ -50,7 +50,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupUtils do
     end
   end
 
-  @spec remove_member_of_crash_group(Pipeline.State.t(), CrashGroup.name_t(), pid()) ::
+  @spec remove_member_of_crash_group(Pipeline.State.t(), CrashGroup.name(), pid()) ::
           Pipeline.State.t()
   def remove_member_of_crash_group(state, group_name, pid) do
     Bunch.Access.update_in(
@@ -60,7 +60,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupUtils do
     )
   end
 
-  @spec get_group_by_member_pid(pid(), Parent.state_t()) ::
+  @spec get_group_by_member_pid(pid(), Parent.state()) ::
           {:ok, CrashGroup.t()} | {:error, :not_member}
   def get_group_by_member_pid(member_pid, state) do
     crash_group =
@@ -76,7 +76,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.CrashGroupUtils do
     end
   end
 
-  @spec set_triggered(Pipeline.State.t(), CrashGroup.name_t(), Membrane.Child.name_t()) ::
+  @spec set_triggered(Pipeline.State.t(), CrashGroup.name(), Membrane.Child.name()) ::
           Pipeline.State.t()
   def set_triggered(state, group_name, crash_initiator) do
     Bunch.Access.update_in(state, [:crash_groups, group_name], fn group ->

--- a/lib/membrane/core/parent/child_life_controller/link_utils.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_utils.ex
@@ -24,7 +24,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
   require Membrane.Logger
   require Membrane.Pad
 
-  @spec unlink_crash_group(CrashGroup.t(), Parent.state_t()) :: Parent.state_t()
+  @spec unlink_crash_group(CrashGroup.t(), Parent.state()) :: Parent.state()
   def unlink_crash_group(crash_group, state) do
     %CrashGroup{members: members_names} = crash_group
 
@@ -33,7 +33,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
     end)
   end
 
-  @spec remove_link(Membrane.Child.name_t(), Pad.ref_t(), Parent.state_t()) :: Parent.state_t()
+  @spec remove_link(Membrane.Child.name(), Pad.ref(), Parent.state()) :: Parent.state()
   def remove_link(child_name, pad_ref, state) do
     Enum.find(state.links, fn {_id, link} ->
       [link.from, link.to]
@@ -61,7 +61,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
     end
   end
 
-  @spec unlink_element(Membrane.Child.name_t(), Parent.state_t()) :: Parent.state_t()
+  @spec unlink_element(Membrane.Child.name(), Parent.state()) :: Parent.state()
   def unlink_element(child_name, state) do
     Map.update!(
       state,
@@ -87,13 +87,13 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
   defp endpoint_to_unlink(_child_name, _link), do: nil
 
   @spec request_link(
-          Membrane.Pad.direction_t(),
+          Membrane.Pad.direction(),
           Link.Endpoint.t(),
           Link.Endpoint.t(),
-          ChildLifeController.spec_ref_t(),
+          ChildLifeController.spec_ref(),
           Link.id(),
-          Parent.state_t()
-        ) :: {[{Link.id(), Membrane.Pad.direction_t()}], Parent.state_t()}
+          Parent.state()
+        ) :: {[{Link.id(), Membrane.Pad.direction()}], Parent.state()}
   def request_link(
         _direction,
         %Link.Endpoint{child: {Membrane.Bin, :itself}} = this,
@@ -122,9 +122,9 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
   end
 
   @spec resolve_links(
-          [SpecificationParser.raw_link_t()],
-          ChildLifeController.spec_ref_t(),
-          Parent.state_t()
+          [SpecificationParser.raw_link()],
+          ChildLifeController.spec_ref(),
+          Parent.state()
         ) :: [
           Link.t()
         ]
@@ -169,7 +169,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
     :ok
   end
 
-  @spec resolve_endpoint(SpecificationParser.raw_endpoint_t(), Parent.state_t()) ::
+  @spec resolve_endpoint(SpecificationParser.raw_endpoint(), Parent.state()) ::
           Endpoint.t() | no_return
   defp resolve_endpoint(
          %Endpoint{child: {Membrane.Bin, :itself}} = endpoint,
@@ -228,7 +228,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
     end
   end
 
-  @spec link(Link.t(), Parent.state_t()) :: Parent.state_t()
+  @spec link(Link.t(), Parent.state()) :: Parent.state()
   def link(%Link{from: %Endpoint{child: child}, to: %Endpoint{child: child}}, _state) do
     raise LinkError, "Tried to link element #{inspect(child)} with itself"
   end

--- a/lib/membrane/core/parent/child_life_controller/startup_utils.ex
+++ b/lib/membrane/core/parent/child_life_controller/startup_utils.ex
@@ -10,7 +10,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
   require Membrane.Core.Message
   require Membrane.Logger
 
-  @spec check_if_children_names_unique([ChildEntryParser.raw_child_entry_t()], Parent.state_t()) ::
+  @spec check_if_children_names_unique([ChildEntryParser.raw_child_entry()], Parent.state()) ::
           :ok | no_return
   def check_if_children_names_unique(children, state) do
     %{children: state_children} = state
@@ -28,8 +28,8 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
     end
   end
 
-  @spec setup_syncs([ChildEntryParser.raw_child_entry_t()], :sinks | [[Membrane.Child.name_t()]]) ::
-          %{Membrane.Child.name_t() => Sync.t()}
+  @spec setup_syncs([ChildEntryParser.raw_child_entry()], :sinks | [[Membrane.Child.name()]]) ::
+          %{Membrane.Child.name() => Sync.t()}
   def setup_syncs(children, :sinks) do
     sinks =
       children
@@ -65,13 +65,13 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
   end
 
   @spec start_children(
-          [ChildEntryParser.raw_child_entry_t()],
+          [ChildEntryParser.raw_child_entry()],
           node() | nil,
           parent_clock :: Clock.t(),
-          syncs :: %{Membrane.Child.name_t() => pid()},
+          syncs :: %{Membrane.Child.name() => pid()},
           log_metadata :: Keyword.t(),
           supervisor :: pid,
-          group :: Membrane.Child.group_t()
+          group :: Membrane.Child.group()
         ) :: [ChildEntry.t()]
   def start_children(
         children,
@@ -94,7 +94,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
     |> Enum.map(&start_child(&1, node, parent_clock, syncs, log_metadata, supervisor, group))
   end
 
-  @spec maybe_activate_syncs(%{Membrane.Child.name_t() => Sync.t()}, Parent.state_t()) ::
+  @spec maybe_activate_syncs(%{Membrane.Child.name() => Sync.t()}, Parent.state()) ::
           :ok | {:error, :bad_activity_request}
   def maybe_activate_syncs(syncs, %{playback: :playing}) do
     syncs |> MapSet.new(&elem(&1, 1)) |> Bunch.Enum.try_each(&Sync.activate/1)
@@ -104,7 +104,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
     :ok
   end
 
-  @spec exec_handle_spec_started([Membrane.Child.name_t()], Parent.state_t()) :: Parent.state_t()
+  @spec exec_handle_spec_started([Membrane.Child.name()], Parent.state()) :: Parent.state()
   def exec_handle_spec_started(children_names, state) do
     action_handler = Component.action_handler(state)
 
@@ -118,8 +118,8 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
   end
 
   @spec check_if_children_names_and_children_groups_ids_are_unique(
-          ChildLifeController.children_spec_canonical_form_t(),
-          Parent.state_t()
+          ChildLifeController.children_spec_canonical_form(),
+          Parent.state()
         ) :: :ok
   def check_if_children_names_and_children_groups_ids_are_unique(children_definitions, state) do
     state_children_groups =

--- a/lib/membrane/core/parent/children_model.ex
+++ b/lib/membrane/core/parent/children_model.ex
@@ -4,15 +4,15 @@ defmodule Membrane.Core.Parent.ChildrenModel do
   alias Membrane.{Child, ChildEntry, UnknownChildError}
   alias Membrane.Core.Parent
 
-  @type children_t :: %{Child.name_t() => ChildEntry.t()}
+  @type children :: %{Child.name() => ChildEntry.t()}
 
-  @spec assert_child_exists!(Parent.state_t(), Child.name_t()) :: :ok
+  @spec assert_child_exists!(Parent.state(), Child.name()) :: :ok
   def assert_child_exists!(state, child) do
     _data = get_child_data!(state, child)
     :ok
   end
 
-  @spec get_child_data!(Parent.state_t(), Child.name_t()) :: ChildEntry.t()
+  @spec get_child_data!(Parent.state(), Child.name()) :: ChildEntry.t()
   def get_child_data!(%{children: children}, child) do
     case children do
       %{^child => data} -> data
@@ -20,8 +20,8 @@ defmodule Membrane.Core.Parent.ChildrenModel do
     end
   end
 
-  @spec update_children!(Parent.state_t(), [Child.name_t()], (ChildEntry.t() -> ChildEntry.t())) ::
-          Parent.state_t()
+  @spec update_children!(Parent.state(), [Child.name()], (ChildEntry.t() -> ChildEntry.t())) ::
+          Parent.state()
   def update_children!(%{children: children} = state, children_names, mapper) do
     children =
       Enum.reduce(children_names, children, fn name, children ->
@@ -34,13 +34,13 @@ defmodule Membrane.Core.Parent.ChildrenModel do
     %{state | children: children}
   end
 
-  @spec update_children(Parent.state_t(), (ChildEntry.t() -> ChildEntry.t())) :: Parent.state_t()
+  @spec update_children(Parent.state(), (ChildEntry.t() -> ChildEntry.t())) :: Parent.state()
   def update_children(%{children: children} = state, mapper) do
     children = Map.new(children, fn {name, entry} -> {name, mapper.(entry)} end)
     %{state | children: children}
   end
 
-  @spec all?(Parent.state_t(), (ChildEntry.t() -> as_boolean(term))) :: boolean()
+  @spec all?(Parent.state(), (ChildEntry.t() -> as_boolean(term))) :: boolean()
   def all?(state, predicate) do
     state.children
     |> Enum.all?(fn {_k, v} -> predicate.(v) end)

--- a/lib/membrane/core/parent/clock_handler.ex
+++ b/lib/membrane/core/parent/clock_handler.ex
@@ -5,11 +5,11 @@ defmodule Membrane.Core.Parent.ClockHandler do
   alias Membrane.Core.Parent.ChildEntryParser
 
   @spec choose_clock(
-          [ChildEntryParser.raw_child_entry_t()],
-          Membrane.Child.name_t() | nil,
-          Core.Parent.state_t()
+          [ChildEntryParser.raw_child_entry()],
+          Membrane.Child.name() | nil,
+          Core.Parent.state()
         ) ::
-          Core.Parent.state_t() | no_return
+          Core.Parent.state() | no_return
   def choose_clock(children, provider, state) do
     %{synchronization: synchronization} = state
 
@@ -28,7 +28,7 @@ defmodule Membrane.Core.Parent.ClockHandler do
     end
   end
 
-  @spec reset_clock(Core.Parent.state_t()) :: Core.Parent.state_t()
+  @spec reset_clock(Core.Parent.state()) :: Core.Parent.state()
   def reset_clock(state),
     do: set_clock_provider(%{clock: nil, provider: nil, choice: :auto}, state)
 

--- a/lib/membrane/core/parent/crash_group.ex
+++ b/lib/membrane/core/parent/crash_group.ex
@@ -8,15 +8,15 @@ defmodule Membrane.Core.Parent.CrashGroup do
 
   use Bunch.Access
 
-  @type name_t() :: any()
+  @type name() :: any()
 
   @type t :: %__MODULE__{
-          name: name_t(),
+          name: name(),
           mode: :temporary,
-          members: [Membrane.Child.name_t()],
+          members: [Membrane.Child.name()],
           alive_members_pids: [pid()],
           triggered?: boolean(),
-          crash_initiator: Membrane.Child.name_t()
+          crash_initiator: Membrane.Child.name()
         }
 
   @enforce_keys [:name, :mode]

--- a/lib/membrane/core/parent/lifecycle_controller.ex
+++ b/lib/membrane/core/parent/lifecycle_controller.ex
@@ -19,7 +19,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
   require Membrane.Core.Message
   require Membrane.Logger
 
-  @spec handle_setup(Parent.state_t()) :: Parent.state_t()
+  @spec handle_setup(Parent.state()) :: Parent.state()
   def handle_setup(state) do
     Membrane.Logger.debug("Setup")
 
@@ -37,7 +37,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
     end
   end
 
-  @spec handle_playing(Parent.state_t()) :: Parent.state_t()
+  @spec handle_playing(Parent.state()) :: Parent.state()
   def handle_playing(state) do
     Membrane.Logger.debug("Parent play")
 
@@ -62,7 +62,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
     )
   end
 
-  @spec handle_terminate_request(Parent.state_t()) :: Parent.state_t()
+  @spec handle_terminate_request(Parent.state()) :: Parent.state()
   def handle_terminate_request(%{terminating?: true} = state) do
     state
   end
@@ -79,7 +79,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
     )
   end
 
-  @spec handle_terminate(Parent.state_t()) :: {:continue | :stop, Parent.state_t()}
+  @spec handle_terminate(Parent.state()) :: {:continue | :stop, Parent.state()}
   def handle_terminate(state) do
     if Enum.empty?(state.children) do
       {:stop, state}
@@ -103,8 +103,8 @@ defmodule Membrane.Core.Parent.LifecycleController do
     end
   end
 
-  @spec handle_child_notification(Child.name_t(), ChildNotification.t(), Parent.state_t()) ::
-          Parent.state_t()
+  @spec handle_child_notification(Child.name(), ChildNotification.t(), Parent.state()) ::
+          Parent.state()
   def handle_child_notification(from, notification, state) do
     Membrane.Logger.debug_verbose(
       "Received notification #{inspect(notification)} from #{inspect(from)}"
@@ -121,7 +121,7 @@ defmodule Membrane.Core.Parent.LifecycleController do
     )
   end
 
-  @spec handle_info(any, Parent.state_t()) :: Parent.state_t()
+  @spec handle_info(any, Parent.state()) :: Parent.state()
   def handle_info(message, state) do
     CallbackHandler.exec_and_handle_callback(
       :handle_info,
@@ -134,10 +134,10 @@ defmodule Membrane.Core.Parent.LifecycleController do
 
   @spec handle_stream_management_event(
           Membrane.Event.t(),
-          Child.name_t(),
-          Pad.ref_t(),
-          Parent.state_t()
-        ) :: Parent.state_t()
+          Child.name(),
+          Pad.ref(),
+          Parent.state()
+        ) :: Parent.state()
   def handle_stream_management_event(%event_type{}, element_name, pad_ref, state)
       when event_type in [Events.StartOfStream, Events.EndOfStream] do
     callback =

--- a/lib/membrane/core/parent/link.ex
+++ b/lib/membrane/core/parent/link.ex
@@ -15,6 +15,6 @@ defmodule Membrane.Core.Parent.Link do
           from: Endpoint.t(),
           to: Endpoint.t(),
           linked?: boolean(),
-          spec_ref: Membrane.Core.Parent.ChildLifeController.spec_ref_t()
+          spec_ref: Membrane.Core.Parent.ChildLifeController.spec_ref()
         }
 end

--- a/lib/membrane/core/parent/link_endpoint.ex
+++ b/lib/membrane/core/parent/link_endpoint.ex
@@ -10,9 +10,9 @@ defmodule Membrane.Core.Parent.Link.Endpoint do
               [pad_ref: nil, pid: nil, pad_props: [], pad_info: %{}, child_spec_ref: nil]
 
   @type t() :: %__MODULE__{
-          child: Element.name_t() | {Membrane.Bin, :itself},
-          pad_spec: Pad.name_t() | Pad.ref_t(),
-          pad_ref: Pad.ref_t(),
+          child: Element.name() | {Membrane.Bin, :itself},
+          pad_spec: Pad.name() | Pad.ref(),
+          pad_ref: Pad.ref(),
           pid: pid(),
           pad_props: map(),
           pad_info: map()

--- a/lib/membrane/core/parent/specification_parser.ex
+++ b/lib/membrane/core/parent/specification_parser.ex
@@ -8,18 +8,18 @@ defmodule Membrane.Core.Parent.SpecificationParser do
 
   require Membrane.Logger
 
-  @type raw_link_t :: %Link{from: raw_endpoint_t(), to: raw_endpoint_t()}
+  @type raw_link :: %Link{from: raw_endpoint(), to: raw_endpoint()}
 
-  @type raw_endpoint_t :: %Endpoint{
-          child: Element.name_t() | {Membrane.Bin, :itself},
-          pad_spec: Pad.name_t() | Pad.ref_t(),
-          pad_ref: Pad.ref_t() | nil,
+  @type raw_endpoint :: %Endpoint{
+          child: Element.name() | {Membrane.Bin, :itself},
+          pad_spec: Pad.name() | Pad.ref(),
+          pad_ref: Pad.ref() | nil,
           pid: pid() | nil,
           pad_props: map()
         }
 
-  @spec parse([ChildrenSpec.builder_t()]) ::
-          {[ChildrenSpec.Builder.child_spec_t()], [raw_link_t]} | no_return
+  @spec parse([ChildrenSpec.builder()]) ::
+          {[ChildrenSpec.Builder.child_spec()], [raw_link]} | no_return
   def parse(specifications) when is_list(specifications) do
     {children, links} =
       specifications
@@ -65,7 +65,7 @@ defmodule Membrane.Core.Parent.SpecificationParser do
 
   def parse(specification), do: from_spec_error([specification])
 
-  @spec from_spec_error([ChildrenSpec.builder_t()]) :: no_return
+  @spec from_spec_error([ChildrenSpec.builder()]) :: no_return
   defp from_spec_error(specifications) do
     raise ParentError, """
     Invalid specifications: #{inspect(specifications)}. The link lacks it destination.

--- a/lib/membrane/core/pipeline/callback_context.ex
+++ b/lib/membrane/core/pipeline/callback_context.ex
@@ -1,11 +1,11 @@
 defmodule Membrane.Core.Pipeline.CallbackContext do
   @moduledoc false
 
-  @type optional_fields_t ::
+  @type optional_fields ::
           [from: GenServer.from()]
-          | [members: [Membrane.Child.name_t()], crash_initiator: Membrane.Child.name_t()]
+          | [members: [Membrane.Child.name()], crash_initiator: Membrane.Child.name()]
 
-  @spec from_state(Membrane.Core.Pipeline.State.t(), optional_fields_t()) ::
+  @spec from_state(Membrane.Core.Pipeline.State.t(), optional_fields()) ::
           Membrane.Pipeline.CallbackContext.t()
   def from_state(state, optional_fields \\ []) do
     Map.new(optional_fields)

--- a/lib/membrane/core/pipeline/state.ex
+++ b/lib/membrane/core/pipeline/state.ex
@@ -15,14 +15,14 @@ defmodule Membrane.Core.Pipeline.State do
   @type t :: %__MODULE__{
           internal_state: Membrane.Pipeline.state() | nil,
           module: module,
-          children: ChildrenModel.children_t(),
-          crash_groups: %{CrashGroup.name_t() => CrashGroup.t()},
+          children: ChildrenModel.children(),
+          crash_groups: %{CrashGroup.name() => CrashGroup.t()},
           links: %{Link.id() => Link.t()},
           synchronization: %{
-            timers: %{Timer.id_t() => Timer.t()},
+            timers: %{Timer.id() => Timer.t()},
             clock_provider: %{
               clock: Membrane.Clock.t() | nil,
-              provider: Child.name_t() | nil,
+              provider: Child.name() | nil,
               choice: :auto | :manual
             },
             clock_proxy: Membrane.Clock.t()

--- a/lib/membrane/core/pipeline/zombie.ex
+++ b/lib/membrane/core/pipeline/zombie.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.Core.Pipeline.Zombie do
   @moduledoc false
-  # When a pipeline returns Membrane.Pipeline.Action.terminate_t()
+  # When a pipeline returns Membrane.Pipeline.Action.terminate()
   # and becomes a zombie-ie-ie oh oh oh oh oh oh oh, ay, oh, ya ya
   # this module is used to replace the user implementation of the pipeline
   use Membrane.Pipeline

--- a/lib/membrane/core/subprocess_supervisor.ex
+++ b/lib/membrane/core/subprocess_supervisor.ex
@@ -29,7 +29,7 @@ defmodule Membrane.Core.SubprocessSupervisor do
   """
   @spec start_component(
           supervisor_pid,
-          name :: Membrane.Child.name_t(),
+          name :: Membrane.Child.name(),
           (supervisor_pid, parent_supervisor_pid -> {:ok, child_pid} | {:error, reason :: any()})
         ) ::
           {:ok, child_pid} | {:error, reason :: any()}

--- a/lib/membrane/core/telemetry.ex
+++ b/lib/membrane/core/telemetry.ex
@@ -65,7 +65,7 @@ defmodule Membrane.Core.Telemetry do
   end
 
   @doc false
-  @spec __get_public_pad_name__(Membrane.Pad.ref_t()) :: Membrane.Pad.ref_t()
+  @spec __get_public_pad_name__(Membrane.Pad.ref()) :: Membrane.Pad.ref()
   def __get_public_pad_name__(pad) do
     case pad do
       {:private, direction} -> direction

--- a/lib/membrane/core/timer.ex
+++ b/lib/membrane/core/timer.ex
@@ -6,22 +6,22 @@ defmodule Membrane.Core.Timer do
 
   require Membrane.Core.Message
 
-  @type id_t :: any()
-  @type interval_t :: Ratio.t() | Time.non_neg_t() | :no_interval
+  @type id :: any()
+  @type interval :: Ratio.t() | Time.non_neg() | :no_interval
   @type t :: %__MODULE__{
-          id: id_t,
-          interval: interval_t,
+          id: id,
+          interval: interval,
           init_time: Time.t(),
           clock: Clock.t(),
           next_tick_time: Time.t(),
-          ratio: Clock.ratio_t(),
+          ratio: Clock.ratio(),
           timer_ref: reference() | nil
         }
 
   @enforce_keys [:interval, :clock, :init_time, :id]
   defstruct @enforce_keys ++ [next_tick_time: 0, ratio: Ratio.new(1), timer_ref: nil]
 
-  @spec start(id_t, interval_t, Clock.t()) :: t
+  @spec start(id, interval, Clock.t()) :: t
   def start(id, interval, clock) do
     %__MODULE__{id: id, interval: interval, init_time: Time.monotonic_time(), clock: clock}
     |> tick
@@ -37,7 +37,7 @@ defmodule Membrane.Core.Timer do
     :ok
   end
 
-  @spec update_ratio(t, Clock.ratio_t()) :: t
+  @spec update_ratio(t, Clock.ratio()) :: t
   def update_ratio(timer, ratio) do
     %__MODULE__{timer | ratio: ratio}
   end
@@ -70,7 +70,7 @@ defmodule Membrane.Core.Timer do
     %__MODULE__{timer | next_tick_time: next_tick_time |> Ratio.floor(), timer_ref: timer_ref}
   end
 
-  @spec set_interval(t, interval_t) :: t
+  @spec set_interval(t, interval) :: t
   def set_interval(%__MODULE__{interval: :no_interval} = timer, interval) do
     %__MODULE__{timer | interval: interval}
     |> tick()

--- a/lib/membrane/core/timer_controller.ex
+++ b/lib/membrane/core/timer_controller.ex
@@ -9,8 +9,8 @@ defmodule Membrane.Core.TimerController do
   defguardp is_timer_present(timer_id, state)
             when is_map_key(state.synchronization.timers, timer_id)
 
-  @spec start_timer(Timer.id_t(), Timer.interval_t(), Clock.t(), Component.state_t()) ::
-          Component.state_t()
+  @spec start_timer(Timer.id(), Timer.interval(), Clock.t(), Component.state()) ::
+          Component.state()
   def start_timer(id, _interval, _clock, state) when is_timer_present(id, state) do
     raise Membrane.TimerError, "Timer #{inspect(id)} already exists"
   end
@@ -21,8 +21,8 @@ defmodule Membrane.Core.TimerController do
     put_in(state, [:synchronization, :timers, id], timer)
   end
 
-  @spec timer_interval(Timer.id_t(), Timer.interval_t(), Component.state_t()) ::
-          Component.state_t()
+  @spec timer_interval(Timer.id(), Timer.interval(), Component.state()) ::
+          Component.state()
   def timer_interval(id, interval, state) do
     with {:ok, timer} <- state.synchronization.timers |> Map.fetch(id) do
       put_in(
@@ -35,7 +35,7 @@ defmodule Membrane.Core.TimerController do
     end
   end
 
-  @spec stop_all_timers(Component.state_t()) :: Component.state_t()
+  @spec stop_all_timers(Component.state()) :: Component.state()
   def stop_all_timers(state) do
     for {_id, timer} <- state.synchronization.timers do
       stop_and_unsubscribe(timer)
@@ -44,7 +44,7 @@ defmodule Membrane.Core.TimerController do
     Bunch.Access.put_in(state, [:synchronization, :timers], %{})
   end
 
-  @spec stop_timer(Timer.id_t(), Component.state_t()) :: Component.state_t()
+  @spec stop_timer(Timer.id(), Component.state()) :: Component.state()
   def stop_timer(id, state) do
     {timer, state} = state |> Bunch.Access.pop_in([:synchronization, :timers, id])
 
@@ -56,7 +56,7 @@ defmodule Membrane.Core.TimerController do
     end
   end
 
-  @spec handle_tick(Timer.id_t(), Component.state_t()) :: Component.state_t()
+  @spec handle_tick(Timer.id(), Component.state()) :: Component.state()
   def handle_tick(timer_id, state) when is_timer_present(timer_id, state) do
     state =
       CallbackHandler.exec_and_handle_callback(
@@ -79,8 +79,8 @@ defmodule Membrane.Core.TimerController do
     state
   end
 
-  @spec handle_clock_update(Timer.id_t(), Clock.ratio_t(), Component.state_t()) ::
-          Component.state_t()
+  @spec handle_clock_update(Timer.id(), Clock.ratio(), Component.state()) ::
+          Component.state()
   def handle_clock_update(clock, ratio, state) do
     update_in(
       state,

--- a/lib/membrane/crash_group.ex
+++ b/lib/membrane/crash_group.ex
@@ -3,7 +3,7 @@ defmodule Membrane.CrashGroup do
   Module containing types and functions for operating on crash groups.
   Crash groups can be used through `Membrane.ChildrenSpec`.
   """
-  @type mode_t() :: :temporary | nil
-  @type name_t() :: any()
-  @type t :: {name_t, mode_t}
+  @type mode() :: :temporary | nil
+  @type name() :: any()
+  @type t :: {name, mode}
 end

--- a/lib/membrane/element.ex
+++ b/lib/membrane/element.ex
@@ -10,12 +10,12 @@ defmodule Membrane.Element do
   Defines options that can be received in `c:Membrane.Element.Base.handle_init/2`
   callback.
   """
-  @type options_t :: struct | nil
+  @type options :: struct | nil
 
   @typedoc """
   Type that defines an element name by which it is identified.
   """
-  @type name_t :: tuple() | atom()
+  @type name :: tuple() | atom()
 
   @typedoc """
   Defines possible element types:
@@ -24,12 +24,12 @@ defmodule Membrane.Element do
   - endpoint, producing and consuming buffers
   - sink, consuming buffers
   """
-  @type type_t :: :source | :filter | :endpoint | :sink
+  @type type :: :source | :filter | :endpoint | :sink
 
   @typedoc """
   Type of user-managed state of element.
   """
-  @type state_t :: any()
+  @type state :: any()
 
   @doc """
   Checks whether module is an element.

--- a/lib/membrane/element/action.ex
+++ b/lib/membrane/element/action.ex
@@ -19,19 +19,19 @@ defmodule Membrane.Element.Action do
 
   Untils the setup lasts, the component won't enter `:playing` playback.
   """
-  @type setup_t :: {:setup, :incomplete | :complete}
+  @type setup :: {:setup, :incomplete | :complete}
 
   @typedoc """
   Sends a message to the parent.
   """
-  @type notify_parent_t :: {:notify_parent, ChildNotification.t()}
+  @type notify_parent :: {:notify_parent, ChildNotification.t()}
 
   @typedoc """
   Sends an event through a pad (input or output).
 
   Allowed only when playback is `playing`.
   """
-  @type event_t :: {:event, {Pad.ref_t(), Event.t()}}
+  @type event :: {:event, {Pad.ref(), Event.t()}}
 
   @typedoc """
   Allows to split callback execution into multiple applications of another callback
@@ -52,7 +52,7 @@ defmodule Membrane.Element.Action do
   `c:Membrane.WithInputPads.handle_buffers_batch/4` uses split action to invoke
   `c:Membrane.WithInputPads.handle_buffer/4` with each buffer)
   """
-  @type split_t :: {:split, {callback_name :: atom, args_list :: [[any]]}}
+  @type split :: {:split, {callback_name :: atom, args_list :: [[any]]}}
 
   @typedoc """
   Sends stream format through a pad.
@@ -61,7 +61,7 @@ defmodule Membrane.Element.Action do
 
   Allowed only when playback is `playing`.
   """
-  @type stream_format_t :: {:stream_format, {Pad.ref_t(), StreamFormat.t()}}
+  @type stream_format :: {:stream_format, {Pad.ref(), StreamFormat.t()}}
 
   @typedoc """
   Sends buffers through a pad.
@@ -70,7 +70,7 @@ defmodule Membrane.Element.Action do
 
   Allowed only when playback is playing.
   """
-  @type buffer_t :: {:buffer, {Pad.ref_t(), Buffer.t() | [Buffer.t()]}}
+  @type buffer :: {:buffer, {Pad.ref(), Buffer.t() | [Buffer.t()]}}
 
   @typedoc """
   Makes a demand on a pad.
@@ -88,8 +88,8 @@ defmodule Membrane.Element.Action do
 
   Allowed only when playback is playing.
   """
-  @type demand_t :: {:demand, {Pad.ref_t(), demand_size_t}}
-  @type demand_size_t :: pos_integer | (pos_integer() -> non_neg_integer())
+  @type demand :: {:demand, {Pad.ref(), demand_size}}
+  @type demand_size :: pos_integer | (pos_integer() -> non_neg_integer())
 
   @typedoc """
   Executes `c:Membrane.Element.WithOutputPads.handle_demand/5` callback
@@ -123,7 +123,7 @@ defmodule Membrane.Element.Action do
   ## Usage limitations
   Allowed only when playback is playing.
   """
-  @type redemand_t :: {:redemand, Pad.ref_t()}
+  @type redemand :: {:redemand, Pad.ref()}
 
   @typedoc """
   Sends buffers/stream format/event to all output pads of element (or to input pads when
@@ -144,7 +144,7 @@ defmodule Membrane.Element.Action do
   forward buffers, `c:Membrane.Element.WithInputPads.handle_stream_format/4` - stream formats
   and `c:Membrane.Element.Base.handle_event/4` - events.
   """
-  @type forward_t ::
+  @type forward ::
           {:forward, Buffer.t() | [Buffer.t()] | StreamFormat.t() | Event.t() | :end_of_stream}
 
   @typedoc """
@@ -152,53 +152,53 @@ defmodule Membrane.Element.Action do
   every `interval` according to the given `clock`.
 
   The timer's `id` is passed to the `c:Membrane.Element.Base.handle_tick/3`
-  callback and can be used for changing its interval via `t:timer_interval_t/0`
-  or stopping it via `t:stop_timer_t/0`.
+  callback and can be used for changing its interval via `t:timer_interval/0`
+  or stopping it via `t:stop_timer/0`.
 
   If `interval` is set to `:no_interval`, the timer won't issue any ticks until
-  the interval is set with `t:timer_interval_t/0` action.
+  the interval is set with `t:timer_interval/0` action.
 
   If no `clock` is passed, parent's clock is chosen.
 
   Timers use `Process.send_after/3` under the hood.
   """
-  @type start_timer_t ::
+  @type start_timer ::
           {:start_timer,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}
-           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval,
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}
+           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval,
               clock :: Clock.t()}}
 
   @typedoc """
-  Changes interval of a timer started with `t:start_timer_t/0`.
+  Changes interval of a timer started with `t:start_timer/0`.
 
   Permitted only from `c:Membrane.Element.Base.handle_tick/3`, unless the interval
   was previously set to `:no_interval`.
 
   If the `interval` is `:no_interval`, the timer won't issue any ticks until
-  another `t:timer_interval_t/0` action. Otherwise, the timer will issue ticks every
+  another `t:timer_interval/0` action. Otherwise, the timer will issue ticks every
   new `interval`. The next tick after interval change is scheduled at
   `new_interval + previous_time`, where previous_time is the time of the latest
-  tick or the time of returning `t:start_timer_t/0` action if no tick has been
+  tick or the time of returning `t:start_timer/0` action if no tick has been
   sent yet. Note that if `current_time - previous_time > new_interval`, a burst
   of `div(current_time - previous_time, new_interval)` ticks is issued immediately.
   """
-  @type timer_interval_t ::
+  @type timer_interval ::
           {:timer_interval,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}}
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}}
 
   @typedoc """
-  Stops a timer started with `t:start_timer_t/0` action.
+  Stops a timer started with `t:start_timer/0` action.
 
   This action is atomic: stopping timer guarantees that no ticks will arrive from it.
   """
-  @type stop_timer_t :: {:stop_timer, timer_id :: any}
+  @type stop_timer :: {:stop_timer, timer_id :: any}
 
   @typedoc """
   This action sets the latency for the element.
 
   This action is not premitted in callback `c:Membrane.Element.Base.handle_init/2`.
   """
-  @type latency_t :: {:latency, latency :: Membrane.Time.non_neg_t()}
+  @type latency :: {:latency, latency :: Membrane.Time.non_neg()}
 
   @typedoc """
   Marks that processing via a pad (output) has been finished and the pad instance
@@ -207,7 +207,7 @@ defmodule Membrane.Element.Action do
   Triggers `end_of_stream/3` callback at the receiver element.
   Allowed only when playback is in playing state.
   """
-  @type end_of_stream_t :: {:end_of_stream, Pad.ref_t()}
+  @type end_of_stream :: {:end_of_stream, Pad.ref()}
 
   @typedoc """
   Terminates element with given reason.
@@ -217,7 +217,7 @@ defmodule Membrane.Element.Action do
     i.e. after `c:Membrane.Element.Base.handle_terminate_request/2` is called
   - If reason is neither `:normal`, `:shutdown` nor `{:shutdown, term}`, an error is logged
   """
-  @type terminate_t :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
+  @type terminate :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
 
   @typedoc """
   Type that defines a single action that may be returned from element callbacks.
@@ -226,19 +226,19 @@ defmodule Membrane.Element.Action do
   circumstances there may be different actions available.
   """
   @type t ::
-          setup_t
-          | event_t
-          | notify_parent_t
-          | split_t
-          | stream_format_t
-          | buffer_t
-          | demand_t
-          | redemand_t
-          | forward_t
-          | start_timer_t
-          | timer_interval_t
-          | stop_timer_t
-          | latency_t
-          | end_of_stream_t
-          | terminate_t
+          setup
+          | event
+          | notify_parent
+          | split
+          | stream_format
+          | buffer
+          | demand
+          | redemand
+          | forward
+          | start_timer
+          | timer_interval
+          | stop_timer
+          | latency
+          | end_of_stream
+          | terminate
 end

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -55,7 +55,7 @@ defmodule Membrane.Element.Base do
   @typedoc """
   Type that defines all valid return values from most callbacks.
   """
-  @type callback_return_t :: {[Action.t()], Element.state_t()}
+  @type callback_return :: {[Action.t()], Element.state()}
 
   @doc """
   Callback invoked on initialization of element.
@@ -65,8 +65,8 @@ defmodule Membrane.Element.Base do
   For these reasons, it's important to do any long-lasting or complex work in `c:handle_setup/2`,
   while `handle_init` should be used for things like parsing options or initializing state.
   """
-  @callback handle_init(context :: CallbackContext.t(), options :: Element.options_t()) ::
-              callback_return_t
+  @callback handle_init(context :: CallbackContext.t(), options :: Element.options()) ::
+              callback_return
 
   @doc """
   Callback invoked on element startup, right after `c:handle_init/2`.
@@ -75,8 +75,8 @@ defmodule Membrane.Element.Base do
   """
   @callback handle_setup(
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback invoked when bin switches the playback to `:playing`.
@@ -86,8 +86,8 @@ defmodule Membrane.Element.Base do
   """
   @callback handle_playing(
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback invoked when element receives a message that is not recognized
@@ -98,8 +98,8 @@ defmodule Membrane.Element.Base do
   @callback handle_info(
               message :: any(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback that is called when new pad has beed added to element. Executed
@@ -108,10 +108,10 @@ defmodule Membrane.Element.Base do
   Context passed to this callback contains additional field `:pad_options`.
   """
   @callback handle_pad_added(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback that is called when some pad of the element has beed removed. Executed
@@ -120,10 +120,10 @@ defmodule Membrane.Element.Base do
   Context passed to this callback contains additional field `:pad_options`.
   """
   @callback handle_pad_removed(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback that is called when event arrives.
@@ -132,21 +132,21 @@ defmodule Membrane.Element.Base do
   forwarded to all output and input pads, respectively.
   """
   @callback handle_event(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               event :: Event.t(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
-  Callback invoked upon each timer tick. A timer can be started with `Membrane.Element.Action.start_timer_t`
+  Callback invoked upon each timer tick. A timer can be started with `Membrane.Element.Action.start_timer`
   action.
   """
   @callback handle_tick(
               timer_id :: any,
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback invoked when a message from the parent is received.
@@ -154,19 +154,19 @@ defmodule Membrane.Element.Base do
   @callback handle_parent_notification(
               notification :: Membrane.ParentNotification.t(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: callback_return_t
+              state :: Element.state()
+            ) :: callback_return
 
   @doc """
   Callback invoked when element is removed by its parent.
 
-  By default it returns `t:Membrane.Element.Action.terminate_t/0` with reason `:normal`.
+  By default it returns `t:Membrane.Element.Action.terminate/0` with reason `:normal`.
   """
   @callback handle_terminate_request(
               context :: CallbackContext.t(),
-              state :: Element.state_t()
+              state :: Element.state()
             ) ::
-              callback_return_t()
+              callback_return()
 
   @doc """
   A callback for constructing struct. Will be defined by `def_options/1` if used.

--- a/lib/membrane/element/callback_context.ex
+++ b/lib/membrane/element/callback_context.ex
@@ -16,10 +16,10 @@ defmodule Membrane.Element.CallbackContext do
   `c:Membrane.Element.WithInputPads.handle_stream_format/4`.
   """
   @type t :: %{
-          :pads => %{Membrane.Pad.ref_t() => Membrane.Element.PadData.t()},
+          :pads => %{Membrane.Pad.ref() => Membrane.Element.PadData.t()},
           :clock => Membrane.Clock.t() | nil,
           :parent_clock => Membrane.Clock.t() | nil,
-          :name => Membrane.Element.name_t(),
+          :name => Membrane.Element.name(),
           :playback => Membrane.Playback.t(),
           :resource_guard => Membrane.ResourceGuard.t(),
           :utility_supervisor => Membrane.UtilitySupervisor.t(),

--- a/lib/membrane/element/pad_data.ex
+++ b/lib/membrane/element/pad_data.ex
@@ -3,16 +3,16 @@ defmodule Membrane.Element.PadData do
   Struct describing current pad state.
 
   The public fields are:
-    - `:availability` - see `t:Membrane.Pad.availability_t/0`
+    - `:availability` - see `t:Membrane.Pad.availability/0`
     - `:stream_format` - the most recent `t:Membrane.StreamFormat.t/0` that have been sent (output) or received (input)
       on the pad. May be `nil` if not yet set.
     - `:demand` - current demand requested on the pad working in `:auto` or `:manual` flow control mode.
-    - `:direction` - see `t:Membrane.Pad.direction_t/0`
+    - `:direction` - see `t:Membrane.Pad.direction/0`
     - `:end_of_stream?` - flag determining whether the stream processing via the pad has been finished
-    - `:flow_control` - see `t:Membrane.Pad.flow_control_t/0`.
-    - `:name` - see `t:Membrane.Pad.name_t/0`. Do not mistake with `:ref`
+    - `:flow_control` - see `t:Membrane.Pad.flow_control/0`.
+    - `:name` - see `t:Membrane.Pad.name/0`. Do not mistake with `:ref`
     - `:options` - options passed in `Membrane.ParentSpec` when linking pad
-    - `:ref` - see `t:Membrane.Pad.ref_t/0`
+    - `:ref` - see `t:Membrane.Pad.ref/0`
     - `:start_of_stream?` - flag determining whether the stream processing via the pad has been started
 
   Other fields in the struct ARE NOT PART OF THE PUBLIC API and should not be
@@ -25,14 +25,14 @@ defmodule Membrane.Element.PadData do
   @type private_field :: term()
 
   @type t :: %__MODULE__{
-          availability: Pad.availability_t(),
+          availability: Pad.availability(),
           stream_format: StreamFormat.t() | nil,
           start_of_stream?: boolean(),
           end_of_stream?: boolean(),
-          direction: Pad.direction_t(),
-          flow_control: Pad.flow_control_t(),
-          name: Pad.name_t(),
-          ref: Pad.ref_t(),
+          direction: Pad.direction(),
+          flow_control: Pad.flow_control(),
+          name: Pad.name(),
+          ref: Pad.ref(),
           options: %{optional(atom) => any},
           stream_format_validation_params: private_field,
           pid: private_field,

--- a/lib/membrane/element/with_input_pads.ex
+++ b/lib/membrane/element/with_input_pads.ex
@@ -21,30 +21,30 @@ defmodule Membrane.Element.WithInputPads do
   Context passed to this callback contains additional field `:old_stream_format`.
   """
   @callback handle_stream_format(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               stream_format :: Membrane.StreamFormat.t(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @doc """
   Callback invoked when element receives `Membrane.Event.StartOfStream` event.
   """
   @callback handle_start_of_stream(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @doc """
   Callback invoked when the previous element has finished processing via the pad,
   and it cannot be used anymore.
   """
   @callback handle_end_of_stream(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @doc """
   Callback that is called when buffer should be processed by the Element.
@@ -57,11 +57,11 @@ defmodule Membrane.Element.WithInputPads do
   For pads in push mode it is invoked when buffers arrive.
   """
   @callback handle_buffers_batch(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               buffers :: list(Buffer.t()),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @doc """
   Callback that is called when buffer should be processed by the Element. In contrast
@@ -70,11 +70,11 @@ defmodule Membrane.Element.WithInputPads do
   Called by default implementation of `c:handle_buffers_batch/4`.
   """
   @callback handle_buffer(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               buffer :: Buffer.t(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @optional_callbacks handle_buffer: 4, handle_stream_format: 4
 

--- a/lib/membrane/element/with_output_pads.ex
+++ b/lib/membrane/element/with_output_pads.ex
@@ -27,17 +27,17 @@ defmodule Membrane.Element.WithOutputPads do
 
   If a source or an endpoint is unable to produce enough buffers, or a filter
   underestimated returned demand, the `:redemand` action should be used (see
-  `t:Membrane.Element.Action.redemand_t/0`).
+  `t:Membrane.Element.Action.redemand/0`).
 
   Context passed to this callback contains additional field `:incoming_demand`.
   """
   @callback handle_demand(
-              pad :: Pad.ref_t(),
+              pad :: Pad.ref(),
               size :: non_neg_integer,
-              unit :: Buffer.Metric.unit_t(),
+              unit :: Buffer.Metric.unit(),
               context :: CallbackContext.t(),
-              state :: Element.state_t()
-            ) :: Membrane.Element.Base.callback_return_t()
+              state :: Element.state()
+            ) :: Membrane.Element.Base.callback_return()
 
   @optional_callbacks handle_demand: 5
 

--- a/lib/membrane/endpoint.ex
+++ b/lib/membrane/endpoint.ex
@@ -35,7 +35,7 @@ defmodule Membrane.Endpoint do
       use Membrane.Element.WithInputPads
 
       @doc false
-      @spec membrane_element_type() :: Membrane.Element.type_t()
+      @spec membrane_element_type() :: Membrane.Element.type()
       def membrane_element_type, do: :endpoint
     end
   end

--- a/lib/membrane/event.ex
+++ b/lib/membrane/event.ex
@@ -3,7 +3,7 @@ defmodule Membrane.Event do
   Event is an entity that can be sent between elements.
 
   Events can flow either downstream or upstream - they can be sent with
-  `t:Membrane.Element.Action.event_t/0`, and can be handled in
+  `t:Membrane.Element.Action.event/0`, and can be handled in
   `c:Membrane.Element.Base.handle_event/4`. Each event is
   to implement `Membrane.EventProtocol`, which allows to configure its behaviour.
   """

--- a/lib/membrane/event/discontinuity.ex
+++ b/lib/membrane/event/discontinuity.ex
@@ -12,9 +12,9 @@ defmodule Membrane.Event.Discontinuity do
   """
   @derive Membrane.EventProtocol
 
-  @type duration_t :: Membrane.Time.t() | nil
+  @type duration :: Membrane.Time.t() | nil
 
   defstruct duration: nil
 
-  @type t :: %__MODULE__{duration: duration_t}
+  @type t :: %__MODULE__{duration: duration}
 end

--- a/lib/membrane/filter.ex
+++ b/lib/membrane/filter.ex
@@ -35,7 +35,7 @@ defmodule Membrane.Filter do
       use Membrane.Element.WithInputPads
 
       @doc false
-      @spec membrane_element_type() :: Membrane.Element.type_t()
+      @spec membrane_element_type() :: Membrane.Element.type()
       def membrane_element_type, do: :filter
 
       @impl true

--- a/lib/membrane/filter_aggregator.ex
+++ b/lib/membrane/filter_aggregator.ex
@@ -21,7 +21,7 @@ defmodule Membrane.FilterAggregator do
   require Membrane.Logger
 
   def_options filters: [
-                spec: [{Membrane.Child.name_t(), module() | struct()}],
+                spec: [{Membrane.Child.name(), module() | struct()}],
                 description: "A list of filters applied to incoming stream"
               ]
 

--- a/lib/membrane/notification.ex
+++ b/lib/membrane/notification.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.ChildNotification do
   @moduledoc """
   A child notification is a message sent from `Membrane.Element` or `Membrane.Bin` to a parent
-  via action `t:Membrane.Element.Action.notify_parent_t` or `t:Membrane.Bin.Action.notify_parent_t`
+  via action `t:Membrane.Element.Action.notify_parent` or `t:Membrane.Bin.Action.notify_parent`
   returned from any callback.
 
   A notification can be handled in parent with
@@ -14,7 +14,7 @@ end
 defmodule Membrane.ParentNotification do
   @moduledoc """
   A parent notification is a message sent from `Membrane.Parent` or `Membrane.Bin` to a child
-  via action `t:Membrane.Pipeline.Action.notify_parent_t` or `t:Membrane.Bin.Action.notify_child_t`
+  via action `t:Membrane.Pipeline.Action.notify_parent` or `t:Membrane.Bin.Action.notify_child`
   returned from any callback.
 
   A notification can be handled in child with `c:Membrane.Element.Base.handle_parent_notification/3` or

--- a/lib/membrane/pad.ex
+++ b/lib/membrane/pad.ex
@@ -19,17 +19,17 @@ defmodule Membrane.Pad do
   @typedoc """
   Defines the term by which the pad instance is identified.
   """
-  @type ref_t :: name_t | {__MODULE__, name_t, dynamic_id_t}
+  @type ref :: name | {__MODULE__, name, dynamic_id}
 
   @typedoc """
   Possible id of dynamic pad
   """
-  @type dynamic_id_t :: any
+  @type dynamic_id :: any
 
   @typedoc """
   Defines the name of pad or group of dynamic pads
   """
-  @type name_t :: atom
+  @type name :: atom
 
   @typedoc """
   Defines possible pad directions:
@@ -39,7 +39,7 @@ defmodule Membrane.Pad do
 
   One cannot link two pads with the same direction.
   """
-  @type direction_t :: :output | :input
+  @type direction :: :output | :input
 
   @typedoc """
   Describes how an element sends and receives data.
@@ -48,8 +48,8 @@ defmodule Membrane.Pad do
   - `:manual` - meaning that the pad works in a pull mode and the demand is manually handled and requested.
   An element with output `:manual` pad can send data through such a pad only if it has already received demand
   on that pad. And element with input `:manual` pad receives data through such a pad only if it has been
-  previously demanded, so that no undemanded data can arrive For more info, see `Membrane.Element.Action.demand_t`,
-  `Membrane.Element.Action.redemand_t` and `c:Membrane.Element.WithOutputPads.handle_demand/5`.
+  previously demanded, so that no undemanded data can arrive For more info, see `Membrane.Element.Action.demand`,
+  `Membrane.Element.Action.redemand` and `c:Membrane.Element.WithOutputPads.handle_demand/5`.
   - `:auto` - meaning that the pad works in a pull mode and the demand is managed automatically:
   the core ensures that there's demand on each input pad (that has `flow_control` set to `:auto`)
   whenever there's demand on all output pads (that have `flow_control` set to `:auto`).
@@ -64,7 +64,7 @@ defmodule Membrane.Pad do
   In such case, however, an error will be raised whenever too many buffers accumulate on the input pad,
   waiting to be processed.
   """
-  @type flow_control_t :: :auto | :manual | :push
+  @type flow_control :: :auto | :manual | :push
 
   @typedoc """
   Values used when defining pad availability:
@@ -75,7 +75,7 @@ defmodule Membrane.Pad do
   instances of the pad, and links each with another pad.
   """
 
-  @type availability_t :: unquote(Bunch.Typespec.enum_to_alternative(@availability_values))
+  @type availability :: unquote(Bunch.Typespec.enum_to_alternative(@availability_values))
 
   @typedoc """
   Type describing availability mode of a created pad:
@@ -85,7 +85,7 @@ defmodule Membrane.Pad do
   entails executing `handle_pad_added` and `handle_pad_removed` callbacks,
   respectively).
   """
-  @type availability_mode_t :: :static | :dynamic
+  @type availability_mode :: :static | :dynamic
 
   @typedoc """
   Describes pattern, that should be matched by stream format send by element on specific
@@ -100,12 +100,12 @@ defmodule Membrane.Pad do
   [:some, :enumeration])` will have this same effect, as `accepted_format: any_of(%My.Format{},
   %My.Another.Format{field: value} when value in [:some, :enumeration])`
   """
-  @type accepted_format_t :: module() | (pattern :: term())
+  @type accepted_format :: module() | (pattern :: term())
 
   @typedoc """
   Describes how a pad should be declared in element or bin.
   """
-  @type spec_t :: element_spec_t | bin_spec_t
+  @type spec :: element_spec | bin_spec
 
   @typedoc """
   Describes how a pad should be declared inside a bin.
@@ -113,33 +113,31 @@ defmodule Membrane.Pad do
   Demand unit is derived from the first element inside the bin linked to the
   given input.
   """
-  @type bin_spec_t ::
-          {name_t(),
-           availability: availability_t(),
-           accepted_format: accepted_format_t(),
-           options: Keyword.t()}
+  @type bin_spec ::
+          {name(),
+           availability: availability(), accepted_format: accepted_format(), options: Keyword.t()}
 
   @typedoc """
   Describes how a pad should be declared inside an element.
   """
-  @type element_spec_t ::
-          {name_t(),
-           availability: availability_t(),
-           accepted_format: accepted_format_t(),
-           flow_control: flow_control_t(),
+  @type element_spec ::
+          {name(),
+           availability: availability(),
+           accepted_format: accepted_format(),
+           flow_control: flow_control(),
            options: Keyword.t(),
-           demand_unit: Buffer.Metric.unit_t()}
+           demand_unit: Buffer.Metric.unit()}
 
   @typedoc """
-  Type describing a pad. Contains data parsed from `t:spec_t/0`
+  Type describing a pad. Contains data parsed from `t:spec/0`
   """
-  @type description_t :: %{
-          :availability => availability_t(),
-          optional(:flow_control) => flow_control_t(),
-          :name => name_t(),
+  @type description :: %{
+          :availability => availability(),
+          optional(:flow_control) => flow_control(),
+          :name => name(),
           :accepted_formats_str => [String.t()],
-          optional(:demand_unit) => Buffer.Metric.unit_t() | nil,
-          :direction => direction_t(),
+          optional(:demand_unit) => Buffer.Metric.unit() | nil,
+          :direction => direction(),
           :options => nil | Keyword.t()
         }
 
@@ -176,18 +174,18 @@ defmodule Membrane.Pad do
   @doc """
   Returns pad availability mode for given availability.
   """
-  @spec availability_mode(availability_t) :: availability_mode_t
+  @spec availability_mode(availability) :: availability_mode
   def availability_mode(:always), do: :static
   def availability_mode(:on_request), do: :dynamic
 
   @doc """
   Returns the name for the given pad reference
   """
-  @spec name_by_ref(ref_t()) :: name_t()
+  @spec name_by_ref(ref()) :: name()
   def name_by_ref(ref(name, _id)) when is_pad_name(name), do: name
   def name_by_ref(name) when is_pad_name(name), do: name
 
-  @spec opposite_direction(direction_t()) :: direction_t()
+  @spec opposite_direction(direction()) :: direction()
   def opposite_direction(:input), do: :output
   def opposite_direction(:output), do: :input
 end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -93,7 +93,7 @@ defmodule Membrane.Pipeline do
       for example. Actions are a tuple of `{type, arguments}`, so may be written in the
       form a keyword list. See `Membrane.Pipeline.Action` for more info.
   """
-  @type callback_return_t ::
+  @type callback_return ::
           {[Action.t()], state}
 
   @doc """
@@ -105,15 +105,15 @@ defmodule Membrane.Pipeline do
   children.
   """
   @callback handle_init(context :: CallbackContext.t(), options :: pipeline_options) ::
-              callback_return_t()
+              callback_return()
 
   @doc """
   Callback invoked when pipeline is requested to terminate with `terminate/2`.
 
-  By default it returns `t:Membrane.Pipeline.Action.terminate_t/0` with reason `:normal`.
+  By default it returns `t:Membrane.Pipeline.Action.terminate/0` with reason `:normal`.
   """
   @callback handle_terminate_request(context :: CallbackContext.t(), state) ::
-              callback_return_t()
+              callback_return()
 
   @doc """
   Callback invoked on pipeline startup, right after `c:handle_init/2`.
@@ -124,7 +124,7 @@ defmodule Membrane.Pipeline do
               context :: CallbackContext.t(),
               state
             ) ::
-              callback_return_t
+              callback_return
 
   @doc """
   Callback invoked when pipeline switches the playback to `:playing`.
@@ -133,17 +133,17 @@ defmodule Membrane.Pipeline do
               context :: CallbackContext.t(),
               state
             ) ::
-              callback_return_t
+              callback_return
 
   @doc """
   Callback invoked when a notification comes in from an element.
   """
   @callback handle_child_notification(
               notification :: Membrane.ChildNotification.t(),
-              element :: Child.name_t(),
+              element :: Child.name(),
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
   Callback invoked when pipeline receives a message that is not recognized
@@ -156,46 +156,46 @@ defmodule Membrane.Pipeline do
               context :: CallbackContext.t(),
               state
             ) ::
-              callback_return_t
+              callback_return
 
   @doc """
   Callback invoked when a child element starts processing stream via given pad.
   """
   @callback handle_element_start_of_stream(
-              child :: Child.name_t(),
-              pad :: Pad.ref_t(),
+              child :: Child.name(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
   Callback invoked when a child element finishes processing stream via given pad.
   """
   @callback handle_element_end_of_stream(
-              child :: Child.name_t(),
-              pad :: Pad.ref_t(),
+              child :: Child.name(),
+              pad :: Pad.ref(),
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
   Callback invoked when children of `Membrane.ChildrenSpec` are started.
   """
   @callback handle_spec_started(
-              children :: [Child.name_t()],
+              children :: [Child.name()],
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
-  Callback invoked upon each timer tick. A timer can be started with `Membrane.Pipeline.Action.start_timer_t`
+  Callback invoked upon each timer tick. A timer can be started with `Membrane.Pipeline.Action.start_timer`
   action.
   """
   @callback handle_tick(
               timer_id :: any,
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
   Callback invoked when crash of the crash group happens.
@@ -203,10 +203,10 @@ defmodule Membrane.Pipeline do
   Context passed to this callback contains 2 additional fields: `:members` and `:crash_initiator`.
   """
   @callback handle_crash_group_down(
-              group_name :: Child.group_t(),
+              group_name :: Child.group(),
               context :: CallbackContext.t(),
               state
-            ) :: callback_return_t
+            ) :: callback_return
 
   @doc """
   Callback invoked when pipeline is called using a synchronous call.
@@ -218,7 +218,7 @@ defmodule Membrane.Pipeline do
               context :: CallbackContext.t(),
               state
             ) ::
-              callback_return_t
+              callback_return
 
   @optional_callbacks handle_init: 2,
                       handle_setup: 2,

--- a/lib/membrane/pipeline/action.ex
+++ b/lib/membrane/pipeline/action.ex
@@ -19,12 +19,12 @@ defmodule Membrane.Pipeline.Action do
 
   Untils the setup lasts, the component won't enter `:playing` playback.
   """
-  @type setup_t :: {:setup, :incomplete | :complete}
+  @type setup :: {:setup, :incomplete | :complete}
 
   @typedoc """
   Action that sends a message to a child identified by name.
   """
-  @type notify_child_t :: {:notify_child, {Child.name_t(), Membrane.ParentNotification.t()}}
+  @type notify_child :: {:notify_child, {Child.name(), Membrane.ParentNotification.t()}}
 
   @typedoc """
   Action that instantiates children and links them according to `Membrane.ChildrenSpec`.
@@ -32,7 +32,7 @@ defmodule Membrane.Pipeline.Action do
   Children's playback is changed to the current pipeline state.
   `c:Membrane.Pipeline.handle_spec_started/3` callback is executed once it happens.
   """
-  @type spec_t :: {:spec, ChildrenSpec.t()}
+  @type spec :: {:spec, ChildrenSpec.t()}
 
   @typedoc """
   Action that stops, unlinks and removes specified child/children from the pipeline.
@@ -40,74 +40,74 @@ defmodule Membrane.Pipeline.Action do
   A child name, list of children names, children group id or a list of children group ids can be specified
   as an argument.
   """
-  @type remove_children_t ::
-          {:remove_children, Child.name_t() | [Child.name_t()]}
+  @type remove_children ::
+          {:remove_children, Child.name() | [Child.name()]}
 
   @typedoc """
   Action that removes link, which relates to specified child and pad.
 
   Removed link has to have dynamic pads on both ends.
   """
-  @type remove_link_t :: {:remove_link, {Child.name_t(), Pad.ref_t()}}
+  @type remove_link :: {:remove_link, {Child.name(), Pad.ref()}}
 
   @typedoc """
   Starts a timer that will invoke `c:Membrane.Pipeline.handle_tick/3` callback
   every `interval` according to the given `clock`.
 
   The timer's `id` is passed to the `c:Membrane.Pipeline.handle_tick/3`
-  callback and can be used for changing its interval via `t:timer_interval_t/0`
-  or stopping it via `t:stop_timer_t/0`.
+  callback and can be used for changing its interval via `t:timer_interval/0`
+  or stopping it via `t:stop_timer/0`.
 
   If `interval` is set to `:no_interval`, the timer won't issue any ticks until
-  the interval is set with `t:timer_interval_t/0` action.
+  the interval is set with `t:timer_interval/0` action.
 
   If no `clock` is passed, pipeline clock is chosen.
 
   Timers use `Process.send_after/3` under the hood.
   """
-  @type start_timer_t ::
+  @type start_timer ::
           {:start_timer,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}
-           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval,
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}
+           | {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval,
               clock :: Membrane.Clock.t()}}
 
   @typedoc """
-  Changes interval of a timer started with `t:start_timer_t/0`.
+  Changes interval of a timer started with `t:start_timer/0`.
 
   Permitted only from `c:Membrane.Pipeline.handle_tick/3`, unless the interval
   was previously set to `:no_interval`.
 
   If the `interval` is `:no_interval`, the timer won't issue any ticks until
-  another `t:timer_interval_t/0` action. Otherwise, the timer will issue ticks every
+  another `t:timer_interval/0` action. Otherwise, the timer will issue ticks every
   new `interval`. The next tick after interval change is scheduled at
   `new_interval + previous_time`, where previous_time is the time of the latest
-  tick or the time of returning `t:start_timer_t/0` action if no tick has been
+  tick or the time of returning `t:start_timer/0` action if no tick has been
   sent yet. Note that if `current_time - previous_time > new_interval`, a burst
   of `div(current_time - previous_time, new_interval)` ticks is issued immediately.
   """
-  @type timer_interval_t ::
+  @type timer_interval ::
           {:timer_interval,
-           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg_t() | :no_interval}}
+           {timer_id :: any, interval :: Ratio.t() | Membrane.Time.non_neg() | :no_interval}}
 
   @typedoc """
-  Stops a timer started with `t:start_timer_t/0` action.
+  Stops a timer started with `t:start_timer/0` action.
 
   This action is atomic: stopping timer guarantees that no ticks will arrive from it.
   """
-  @type stop_timer_t :: {:stop_timer, timer_id :: any}
+  @type stop_timer :: {:stop_timer, timer_id :: any}
 
   @typedoc """
   Action that replies to a `Membrane.Pipeline.call/3`. Can be returned only from the `c:Membrane.Pipeline.handle_call/3` callback, in
   which context the caller reference is available, under the `:from` key.
   """
-  @type reply_t :: {:reply, message :: any}
+  @type reply :: {:reply, message :: any}
 
   @typedoc """
   Action that replies to a `Membrane.Pipeline.call/3`. Useful when one does not want to reply in
   `c:Membrane.Pipeline.handle_call/3` callback. A caller reference is required to be passed, so one needs to save this
   reference from the `Membrane.Pipeline.CallbackContext.Call`, where it is available under the `:from` key.
   """
-  @type reply_to_t :: {:reply_to, {GenServer.from(), message :: any}}
+  @type reply_to :: {:reply_to, {GenServer.from(), message :: any}}
 
   @typedoc """
   Terminates the pipeline with given reason.
@@ -122,7 +122,7 @@ defmodule Membrane.Pipeline.Action do
   terminates all the children with the reason `:shutdown`
   - If the reason is neither `:normal`, `:shutdown` nor `{:shutdown, term}`, an error is logged
   """
-  @type terminate_t :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
+  @type terminate :: {:terminate, reason :: :normal | :shutdown | {:shutdown, term} | term}
 
   @typedoc """
   Type describing actions that can be returned from pipeline callbacks.
@@ -131,15 +131,15 @@ defmodule Membrane.Pipeline.Action do
   other parts of framework.
   """
   @type t ::
-          setup_t
-          | notify_child_t
-          | spec_t
-          | remove_children_t
-          | remove_link_t
-          | start_timer_t
-          | timer_interval_t
-          | stop_timer_t
-          | reply_t
-          | reply_to_t
-          | terminate_t
+          setup
+          | notify_child
+          | spec
+          | remove_children
+          | remove_link
+          | start_timer
+          | timer_interval
+          | stop_timer
+          | reply
+          | reply_to
+          | terminate
 end

--- a/lib/membrane/pipeline/callback_context.ex
+++ b/lib/membrane/pipeline/callback_context.ex
@@ -13,12 +13,12 @@ defmodule Membrane.Pipeline.CallbackContext do
   """
   @type t :: %{
           :clock => Membrane.Clock.t(),
-          :children => %{Membrane.Child.name_t() => Membrane.ChildEntry.t()},
+          :children => %{Membrane.Child.name() => Membrane.ChildEntry.t()},
           :playback => Membrane.Playback.t(),
           :resource_guard => Membrane.ResourceGuard.t(),
           :utility_supervisor => Membrane.UtilitySupervisor.t(),
           optional(:from) => [GenServer.from()],
-          optional(:members) => [Membrane.Child.name_t()],
-          optional(:crash_initiator) => Membrane.Child.name_t()
+          optional(:members) => [Membrane.Child.name()],
+          optional(:crash_initiator) => Membrane.Child.name()
         }
 end

--- a/lib/membrane/rc_message.ex
+++ b/lib/membrane/rc_message.ex
@@ -28,8 +28,8 @@ defmodule Membrane.RCMessage do
     """
     @type t :: %__MODULE__{
             from: pid(),
-            element: Membrane.Element.name_t(),
-            pad: Membrane.Pad.name_t()
+            element: Membrane.Element.name(),
+            pad: Membrane.Pad.name()
           }
 
     @enforce_keys [:from, :element, :pad]
@@ -42,8 +42,8 @@ defmodule Membrane.RCMessage do
     """
     @type t :: %__MODULE__{
             from: pid(),
-            element: Membrane.Element.name_t(),
-            pad: Membrane.Pad.name_t()
+            element: Membrane.Element.name(),
+            pad: Membrane.Pad.name()
           }
 
     @enforce_keys [:from, :element, :pad]
@@ -56,7 +56,7 @@ defmodule Membrane.RCMessage do
     """
     @type t :: %__MODULE__{
             from: pid(),
-            element: Membrane.Element.name_t(),
+            element: Membrane.Element.name(),
             data: Membrane.ParentNotification.t()
           }
 

--- a/lib/membrane/rc_pipeline.ex
+++ b/lib/membrane/rc_pipeline.ex
@@ -166,7 +166,7 @@ defmodule Membrane.RCPipeline do
     Pipeline.await_start_of_stream(pipeline, :element_id)
     ```
   """
-  @spec await_start_of_stream(pid(), Membrane.Element.name_t()) ::
+  @spec await_start_of_stream(pid(), Membrane.Element.name()) ::
           Membrane.RCMessage.StartOfStream.t()
   def await_start_of_stream(pipeline, element) do
     do_await(pipeline, StartOfStream, element: element)
@@ -184,7 +184,7 @@ defmodule Membrane.RCPipeline do
     Pipeline.await_start_of_stream(pipeline, :element_id, :pad_id)
     ```
   """
-  @spec await_start_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
+  @spec await_start_of_stream(pid(), Membrane.Element.name(), Membrane.Pad.name()) ::
           Membrane.RCMessage.StartOfStream.t()
   def await_start_of_stream(pipeline, element, pad) do
     do_await(pipeline, StartOfStream, element: element, pad: pad)
@@ -219,7 +219,7 @@ defmodule Membrane.RCPipeline do
     Pipeline.await_end_of_stream(pipeline, :element_id)
     ```
   """
-  @spec await_end_of_stream(pid(), Membrane.Element.name_t()) ::
+  @spec await_end_of_stream(pid(), Membrane.Element.name()) ::
           Membrane.RCMessage.EndOfStream.t()
   def await_end_of_stream(pipeline, element) do
     do_await(pipeline, EndOfStream, element: element)
@@ -237,7 +237,7 @@ defmodule Membrane.RCPipeline do
     Pipeline.await_end_of_stream(pipeline, :element_id, :pad_id)
     ```
   """
-  @spec await_end_of_stream(pid(), Membrane.Element.name_t(), Membrane.Pad.name_t()) ::
+  @spec await_end_of_stream(pid(), Membrane.Element.name(), Membrane.Pad.name()) ::
           Membrane.RCMessage.EndOfStream.t()
   def await_end_of_stream(pipeline, element, pad) do
     do_await(pipeline, EndOfStream, element: element, pad: pad)

--- a/lib/membrane/sink.ex
+++ b/lib/membrane/sink.ex
@@ -10,7 +10,7 @@ defmodule Membrane.Sink do
   data on such pad and consume it (write to a soundcard, send through TCP etc.).
   If the pad works in pull mode (with `:auto` or `:manual` flow control), which is
   the most common case, then element is also responsible for requesting demands when
-  it is able and willing to consume data (for more details, see `t:Membrane.Element.Action.demand_t/0`).
+  it is able and willing to consume data (for more details, see `t:Membrane.Element.Action.demand/0`).
   Sinks, like all elements, can of course have multiple pads if needed to
   provide more complex solutions.
   """
@@ -31,7 +31,7 @@ defmodule Membrane.Sink do
       use Membrane.Element.WithInputPads
 
       @doc false
-      @spec membrane_element_type() :: Membrane.Element.type_t()
+      @spec membrane_element_type() :: Membrane.Element.type()
       def membrane_element_type, do: :sink
     end
   end

--- a/lib/membrane/source.ex
+++ b/lib/membrane/source.ex
@@ -33,7 +33,7 @@ defmodule Membrane.Source do
       use Membrane.Element.WithOutputPads
 
       @doc false
-      @spec membrane_element_type() :: Membrane.Element.type_t()
+      @spec membrane_element_type() :: Membrane.Element.type()
       def membrane_element_type, do: :source
     end
   end

--- a/lib/membrane/sync.ex
+++ b/lib/membrane/sync.ex
@@ -34,7 +34,7 @@ defmodule Membrane.Sync do
   @no_sync :membrane_no_sync
 
   @type t :: pid | :membrane_no_sync
-  @type status_t :: :registered | :sync
+  @type status :: :registered | :sync
 
   @doc """
   Starts a Sync process linked to the current process.

--- a/lib/membrane/telemetry.ex
+++ b/lib/membrane/telemetry.ex
@@ -11,19 +11,19 @@ defmodule Membrane.Telemetry do
   The following events are published by Membrane's Core with following measurement types and metadata:
 
     * `[:membrane, :metric, :value]` - used to report metrics, such as input buffer's size inside functions, incoming events and received stream format
-        * Measurement: `t:metric_event_value_t/0`
+        * Measurement: `t:metric_event_value/0`
         * Metadata: `%{}`
 
     * `[:membrane, :link, :new]` - to report new link connection being initialized in pipeline.
-        * Measurement: `t:link_event_value_t/0`
+        * Measurement: `t:link_event_value/0`
         * Metadata: `%{}`
 
     * `[:membrane, :pipeline | :bin | :element, :init]` - to report pipeline/element/bin initialization
-        * Measurement: `t:init_or_terminate_event_value_t/0`
+        * Measurement: `t:init_or_terminate_event_value/0`
         * Metadata: `%{log_metadata: keyword()}`, includes Logger's metadata of created component
 
     * `[:membrane, :pipeline | :bin | :element, :terminate]` - to report pipeline/element/bin termination
-        * Measurement: `t:init_or_terminate_event_value_t/0`
+        * Measurement: `t:init_or_terminate_event_value/0`
         * Metadata: `%{}`
 
 
@@ -61,14 +61,14 @@ defmodule Membrane.Telemetry do
   * `:take_and_demand` - reports the current size of a input buffer when taking buffers and making a new demand
   """
 
-  @type event_name_t :: [atom(), ...]
+  @type event_name :: [atom(), ...]
 
   @typedoc """
   * component_path - element's or bin's path
   * metric - metric's name
   * value - metric's value
   """
-  @type metric_event_value_t :: %{
+  @type metric_event_value :: %{
           component_path: String.t(),
           metric: String.t(),
           value: integer()
@@ -77,8 +77,8 @@ defmodule Membrane.Telemetry do
   @typedoc """
   * path - element's path
   """
-  @type init_or_terminate_event_value_t :: %{
-          path: Membrane.ComponentPath.path_t()
+  @type init_or_terminate_event_value :: %{
+          path: Membrane.ComponentPath.path()
         }
 
   @typedoc """
@@ -88,7 +88,7 @@ defmodule Membrane.Telemetry do
   * pad_from - from's pad name
   * pad_to - to's pad name
   """
-  @type link_event_value_t :: %{
+  @type link_event_value :: %{
           parent_path: String.t(),
           from: String.t(),
           to: String.t(),

--- a/lib/membrane/testing/dynamic_source.ex
+++ b/lib/membrane/testing/dynamic_source.ex
@@ -37,7 +37,7 @@ defmodule Membrane.Testing.DynamicSource do
   alias Membrane.Element.Action
 
   @type generator ::
-          (state :: any(), pad :: Pad.ref_t(), buffers_cnt :: pos_integer ->
+          (state :: any(), pad :: Pad.ref(), buffers_cnt :: pos_integer ->
              {[Action.t()], state :: any()})
 
   def_output_pad :output, flow_control: :manual, accepted_format: _any, availability: :on_request
@@ -48,7 +48,7 @@ defmodule Membrane.Testing.DynamicSource do
                 description: """
                 If `output` is an enumerable with `t:Membrane.Payload.t/0` then
                 buffer containing those payloads will be sent through the
-                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream_t/0`.
+                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream/0`.
 
                 If `output` is a `{initial_state, function}` tuple then the
                 the function will be invoked each time `handle_demand` is called.
@@ -70,7 +70,7 @@ defmodule Membrane.Testing.DynamicSource do
                 """
               ]
 
-  @spec default_buf_gen(integer(), Pad.ref_t(), integer()) :: {[Action.t()], integer()}
+  @spec default_buf_gen(integer(), Pad.ref(), integer()) :: {[Action.t()], integer()}
   def default_buf_gen(generator_state, pad, size) do
     buffers =
       generator_state..(size + generator_state - 1)

--- a/lib/membrane/testing/endpoint.ex
+++ b/lib/membrane/testing/endpoint.ex
@@ -31,7 +31,7 @@ defmodule Membrane.Testing.Endpoint do
                 description: """
                 If `output` is an enumerable with `t:Membrane.Payload.t/0` then
                 buffer containing those payloads will be sent through the
-                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream_t/0`.
+                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream/0`.
 
                 If `output` is a `{initial_state, function}` tuple then the
                 the function will be invoked each time `handle_demand` is called.

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -116,7 +116,7 @@ defmodule Membrane.Testing.Pipeline do
   @type options ::
           [
             module: :default,
-            spec: [ChildrenSpec.builder_t()],
+            spec: [ChildrenSpec.builder()],
             test_process: pid(),
             name: Pipeline.name()
           ]
@@ -204,7 +204,7 @@ defmodule Membrane.Testing.Pipeline do
 
       message_child(pipeline, :sink, {:message, "to handle"})
   """
-  @spec message_child(pid(), Element.name_t(), any()) :: :ok
+  @spec message_child(pid(), Element.name(), any()) :: :ok
   def message_child(pipeline, child, message) do
     send(pipeline, {:for_element, child, message})
     :ok
@@ -237,7 +237,7 @@ defmodule Membrane.Testing.Pipeline do
    * `{:ok, child_pid}`, if a child was succesfully found
    * `{:error, reason}`, if, for example, pipeline is not alive or children path is invalid
   """
-  @spec get_child_pid(pid(), child_ref_path :: Child.ref_t() | [Child.ref_t()]) ::
+  @spec get_child_pid(pid(), child_ref_path :: Child.ref() | [Child.ref()]) ::
           {:ok, pid()} | {:error, reason :: term()}
   def get_child_pid(pipeline, [_head | _tail] = child_ref_path) do
     do_get_child_pid(pipeline, child_ref_path)
@@ -253,7 +253,7 @@ defmodule Membrane.Testing.Pipeline do
   Works as get_child_pid/2, but raises an error instead of returning
   `{:error, reason}` tuple.
   """
-  @spec get_child_pid!(pid(), child_ref_path :: Child.ref_t() | [Child.ref_t()]) :: pid()
+  @spec get_child_pid!(pid(), child_ref_path :: Child.ref() | [Child.ref()]) :: pid()
   def get_child_pid!(parent_pid, child_ref_path) do
     {:ok, child_pid} = get_child_pid(parent_pid, child_ref_path)
     child_pid

--- a/lib/membrane/testing/source.ex
+++ b/lib/membrane/testing/source.ex
@@ -45,7 +45,7 @@ defmodule Membrane.Testing.Source do
                 description: """
                 If `output` is an enumerable with `t:Membrane.Payload.t/0` then
                 buffer containing those payloads will be sent through the
-                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream_t/0`.
+                `:output` pad and followed by `t:Membrane.Element.Action.end_of_stream/0`.
 
                 If `output` is a `{initial_state, function}` tuple then the
                 the function will be invoked each time `handle_demand` is called.

--- a/lib/membrane/time.ex
+++ b/lib/membrane/time.ex
@@ -17,7 +17,7 @@ defmodule Membrane.Time do
             native_units: 1, native_unit: 0, nanoseconds: 1, nanosecond: 0, second: 0, seconds: 1}
 
   @type t :: integer
-  @type non_neg_t :: non_neg_integer
+  @type non_neg :: non_neg_integer
 
   @units [
     %{plural: :days, singular: :day, abbrev: "d", duration: 86_400_000_000_000},

--- a/test/membrane/filter_aggregator/unit_test.exs
+++ b/test/membrane/filter_aggregator/unit_test.exs
@@ -10,7 +10,7 @@ defmodule Membrane.FilterAggregator.UnitTest do
   alias Membrane.StreamFormat.Mock, as: MockStreamFormat
 
   defmodule ElementWithMembranePads do
-    @callback membrane_pads() :: [{Membrane.Pad.name_t(), Membrane.Pad.description_t()}]
+    @callback membrane_pads() :: [{Membrane.Pad.name(), Membrane.Pad.description()}]
   end
 
   setup_all do

--- a/test/support/child_removal_test/pipeline.ex
+++ b/test/support/child_removal_test/pipeline.ex
@@ -16,7 +16,7 @@ defmodule Membrane.Support.ChildRemovalTest.Pipeline do
   """
   use Membrane.Pipeline
 
-  @spec remove_child(pid(), Membrane.Child.name_t()) :: any()
+  @spec remove_child(pid(), Membrane.Child.name()) :: any()
   def remove_child(pid, child_name) do
     send(pid, {:remove_children, child_name})
   end


### PR DESCRIPTION
Used the following regex (in VS Code) :D
from `_t([^a-z]|$)`
to `$1`