### PR TITLE
Add get_stats

### DIFF
--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -220,6 +220,21 @@ defmodule Membrane.Core.Element do
     {:noreply, state}
   end
 
+  defp do_handle_info(Message.new(:get_stats, [from, ref]), state) do
+    avg_proc_time =
+      if state.buffers_recv == 0, do: 0, else: state.buffers_proc_time / state.buffers_recv
+
+    stats = %{
+      buffers_sent: state.buffers_sent,
+      buffers_recv: state.buffers_recv,
+      avg_proc_time: avg_proc_time
+    }
+
+    send(from, {:get_stats, ref, stats})
+
+    {:noreply, state}
+  end
+
   defp do_handle_info(Message.new(_type, _args, _opts) = message, _state) do
     raise Membrane.ElementError, "Received invalid message #{inspect(message)}"
   end

--- a/lib/membrane/core/element/action_handler.ex
+++ b/lib/membrane/core/element/action_handler.ex
@@ -310,6 +310,8 @@ defmodule Membrane.Core.Element.ActionHandler do
         DemandHandler.handle_outgoing_buffers(pad_ref, pad_data, buffers, state)
         |> PadModel.set_data!(pad_ref, :start_of_stream?, true)
 
+      state = %{state | buffers_sent: state.buffers_sent + length(buffers)}
+
       Message.send(pid, :buffer, buffers, for_pad: other_ref)
       state
     else

--- a/lib/membrane/core/element/state.ex
+++ b/lib/membrane/core/element/state.ex
@@ -36,7 +36,10 @@ defmodule Membrane.Core.Element.State do
           resource_guard: Membrane.ResourceGuard.t(),
           subprocess_supervisor: pid,
           terminating?: boolean(),
-          setup_incomplete?: boolean()
+          setup_incomplete?: boolean(),
+          buffers_recv: non_neg_integer(),
+          buffers_sent: non_neg_integer(),
+          buffers_proc_time: non_neg_integer()
         }
 
   defstruct [
@@ -57,7 +60,10 @@ defmodule Membrane.Core.Element.State do
     :resource_guard,
     :subprocess_supervisor,
     :terminating?,
-    :setup_incomplete?
+    :setup_incomplete?,
+    buffers_recv: 0,
+    buffers_sent: 0,
+    buffers_proc_time: 0
   ]
 
   @doc """

--- a/lib/membrane/core/get_stats_task.ex
+++ b/lib/membrane/core/get_stats_task.ex
@@ -1,0 +1,21 @@
+defmodule Membrane.Core.GetStatsTask do
+  alias Membrane.Core.Message
+
+  def run(child_pid, child_name) do
+    monitor_ref = Process.monitor(child_pid)
+    msg_ref = make_ref()
+
+    Message.send(child_pid, :get_stats, [self(), msg_ref])
+
+    receive do
+      {:DOWN, ^monitor_ref, :process, ^child_pid, _reason} ->
+        nil
+
+      {:get_stats, ^msg_ref, stats} ->
+        {child_name, stats}
+    after
+      1000 ->
+        nil
+    end
+  end
+end

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -294,6 +294,10 @@ defmodule Membrane.Pipeline do
     end
   end
 
+  def get_stats(pipeline) do
+    Membrane.Core.Message.call(pipeline, :get_stats)
+  end
+
   @doc """
   Gracefully terminates the pipeline.
 

--- a/test/membrane/core/element/action_handler_test.exs
+++ b/test/membrane/core/element/action_handler_test.exs
@@ -143,7 +143,9 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
           state
         )
 
-      assert result == state
+      expected_state = %{state | buffers_sent: 1}
+
+      assert result == expected_state
       assert_received Message.new(:buffer, [@mock_buffer], for_pad: :other_ref)
     end
 
@@ -160,7 +162,9 @@ defmodule Membrane.Core.Element.ActionHandlerTest do
           state
         )
 
-      assert result == state
+      expected_state = %{state | buffers_sent: 1}
+
+      assert result == expected_state
       assert_received Message.new(:buffer, [@mock_buffer], for_pad: :other_ref)
     end
 


### PR DESCRIPTION
This is the PoC of an alternative API for getting pipeline statistics. The API is blocking but I belive it can be easily modified to be non-blocking e.g. we could operate on sending messages instead of using GenServer.call and return a task to the user so it can await it instead of receive result manually.  We would also have to think about resetting integers after some time to prevent from memory leak.

This API should be more performant than relaying on telemetry events and easier in usage as a user doesn't have to write its own exporter, which consumes telemetry events.

Even if we don't want to use it in production, it can be very usful for debugging, e.g. we could extend this API with `find_bottleneck` function that will go through the raport and find the slowest element (element which `avg_proc_time` is the highest).

Example result looks like this (the easiest way was to return a map of maps but we could convert it to something that can be easily converted to a JSON)

```elixir
%{
  {:endpoint, "4f2ba33c-746f-46aa-812e-e89b6d0a588d"} => %{
    endpoint_bin: %{
      ice: %{avg_proc_time: 0, buffers_recv: 0, buffers_sent: 0},
      ice_funnel: %{avg_proc_time: 0, buffers_recv: 0, buffers_sent: 0},
      rtp: %{
        :ssrc_router => %{avg_proc_time: 0, buffers_recv: 0, buffers_sent: 0},
        {:rtcp_parser, #Reference<0.3468890940.1030750210.213394>} => %{
          avg_proc_time: 0,
          buffers_recv: 0,
          buffers_sent: 0
        },
        {:rtp_parser, #Reference<0.3468890940.1030750210.213394>} => %{
          avg_proc_time: 0,
          buffers_recv: 0,
          buffers_sent: 0
        },
        {:srtcp_decryptor, #Reference<0.3468890940.1030750210.213394>} => %{
          avg_proc_time: 0,
          buffers_recv: 0,
          buffers_sent: 0
        },
        {:srtcp_encryptor, #Reference<0.3468890940.1030750210.213394>} => %{
          avg_proc_time: 0,
          buffers_recv: 0,
          buffers_sent: 0
        }
      }
    }
  },
  {:endpoint, "779e3aa3-6219-4ea0-b10c-27284fa1ee3e"} => %{
    :endpoint_bin => %{
      ice: %{
        avg_proc_time: 21912.37439598752,
        buffers_recv: 32698,
        buffers_sent: 26758
      },
      ice_funnel: %{
        avg_proc_time: 11206.095602177504,
        buffers_recv: 32698,
        buffers_sent: 32698
      },
      rtp: %{
        :ssrc_router => %{
          avg_proc_time: 22196.655931760815,
          buffers_recv: 22978,
          buffers_sent: 22976
        },
        :twcc_receiver => %{
          avg_proc_time: 28917.698581251632,
          buffers_recv: 22978,
          buffers_sent: 22978
        },
        :twcc_sender => %{
          avg_proc_time: 30084.697466227135,
          buffers_recv: 30942,
          buffers_sent: 30942
        },
        {:outbound_rtx_controller, 456996278} => %{
          avg_proc_time: 35604.687479537904,
          buffers_recv: 21381,
          buffers_sent: 21381
        },
        {:outbound_rtx_controller, 2203412721} => %{
          avg_proc_time: 36530.615939755255,
          buffers_recv: 9561,
          buffers_sent: 9561
        },
        {:rtcp_parser, #Reference<0.3468890940.1030750213.212304>} => %{
          avg_proc_time: 42264.88544973545,
          buffers_recv: 3780,
          buffers_sent: 1374
        },
        {:rtp_parser, #Reference<0.3468890940.1030750213.212304>} => %{
          avg_proc_time: 23623.140668211377,
          buffers_recv: 26758,
          buffers_sent: 26758
        },
        {:srtcp_decryptor, #Reference<0.3468890940.1030750213.212304>} => %{
          avg_proc_time: 52481.635714285716,
          buffers_recv: 3780,
          buffers_sent: 3780
        },
        {:srtcp_encryptor, #Reference<0.3468890940.1030750213.212304>} => %{
          avg_proc_time: 60051.03493449782,
          buffers_recv: 1374,
          buffers_sent: 1374
        },
        {:srtcp_sender_encryptor, 456996278} => %{
          avg_proc_time: 68639.15183246073,
          buffers_recv: 191,
          buffers_sent: 191
        },
        {:srtcp_sender_encryptor, 2203412721} => %{
          avg_proc_time: 64928.51832460733,
          buffers_recv: 191,
          buffers_sent: 191
        },
        {:srtp_encryptor, 456996278} => %{
          avg_proc_time: 51530.88391562602,
          buffers_recv: 21381,
          buffers_sent: 21381
        },
        {:srtp_encryptor, 2203412721} => %{
          avg_proc_time: 43087.87218910156,
          buffers_recv: 9561,
          buffers_sent: 9561
        },
        {:stream_receive_bin, 2144461489} => %{
          decryptor: %{
            avg_proc_time: 64103.07150480256,
            buffers_recv: 2811,
            buffers_sent: 2811
          },
          packet_tracker: %{
            avg_proc_time: 37545.642475987195,
            buffers_recv: 2811,
            buffers_sent: 2811
          },
          rtcp_receiver: %{
            avg_proc_time: 12527.303450729278,
            buffers_recv: 2811,
            buffers_sent: 2811
          }
        },
        {:stream_receive_bin, 2600757121} => %{
          decryptor: %{
            avg_proc_time: 62751.020833333336,
            buffers_recv: 10320,
            buffers_sent: 10320
          },
          packet_tracker: %{
            avg_proc_time: 30831.070445736434,
            buffers_recv: 10320,
            buffers_sent: 10320
          },
          rtcp_receiver: %{
            avg_proc_time: 8164.880426356589,
            buffers_recv: 10320,
            buffers_sent: 10320
          }
        },
        {:stream_receive_bin, 3250387553} => %{
          decryptor: %{
            avg_proc_time: 63429.630141159745,
            buffers_recv: 9847,
            buffers_sent: 9847
          },
          packet_tracker: %{
            avg_proc_time: 37611.63968721438,
            buffers_recv: 9847,
            buffers_sent: 9847
          },
          rtcp_receiver: %{
            avg_proc_time: 9261.568091804611,
            buffers_recv: 9847,
            buffers_sent: 9847
          }
        },
        {:stream_send_bin, 456996278} => %{
          packet_tracker: %{
            avg_proc_time: 31142.68911650531,
            buffers_recv: 21381,
            buffers_sent: 21572
          }
        },
        {:stream_send_bin, 2203412721} => %{
          packet_tracker: %{
            avg_proc_time: 34522.214517309905,
            buffers_recv: 9561,
            buffers_sent: 9752
          }
        }
      }
    },
    {:track_receiver,
     "f33c2f00-4730-4805-bd86-04a5ada402ec:5671201d-cef4-4f0f-94b8-ef38dea6073b"} => %{
      avg_proc_time: 39813.65309734513,
      buffers_recv: 10170,
      buffers_sent: 21381
    },
    {:track_receiver,
     "f33c2f00-4730-4805-bd86-04a5ada402ec:779faa6c-9c26-438a-8852-df6b7959bb5e"} => %{
      avg_proc_time: 20589.7534776697,
      buffers_recv: 9561,
      buffers_sent: 9561
    },
    {:track_sender,
     "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:0d9986a4-cbfd-4e30-8ccb-0f8075965679"} => %{
      avg_proc_time: 46272.240174672486,
      buffers_recv: 9847,
      buffers_sent: 9847
    },
    {:track_sender,
     "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:e8fa49d1-fd03-41c3-a6eb-1c82b1257c13"} => %{
      avg_proc_time: 51625.24141344909,
      buffers_recv: 13131,
      buffers_sent: 13131
    }
  },
  {:endpoint, "f33c2f00-4730-4805-bd86-04a5ada402ec"} => %{
    :endpoint_bin => %{
      ice: %{
        avg_proc_time: 19914.386699806015,
        buffers_recv: 32992,
        buffers_sent: 26159
      },
      ice_funnel: %{
        avg_proc_time: 10551.839839961203,
        buffers_recv: 32992,
        buffers_sent: 32992
      },
      rtp: %{
        :ssrc_router => %{
          avg_proc_time: 23643.520541216396,
          buffers_recv: 22394,
          buffers_sent: 22392
        },
        :twcc_receiver => %{
          avg_proc_time: 30907.530633205322,
          buffers_recv: 22394,
          buffers_sent: 22393
        },
        :twcc_sender => %{
          avg_proc_time: 28796.158916464115,
          buffers_recv: 31268,
          buffers_sent: 31268
        },
        {:outbound_rtx_controller, 2441442936} => %{
          avg_proc_time: 33279.51800451842,
          buffers_recv: 21689,
          buffers_sent: 21690
        },
        {:outbound_rtx_controller, 2832125492} => %{
          avg_proc_time: 42144.696419250446,
          buffers_recv: 9579,
          buffers_sent: 9579
        },
        {:rtcp_parser, #Reference<0.3468890940.1030750211.215664>} => %{
          avg_proc_time: 31905.985126162017,
          buffers_recv: 3765,
          buffers_sent: 1340
        },
        {:rtp_parser, #Reference<0.3468890940.1030750211.215664>} => %{
          avg_proc_time: 24863.822126228068,
          buffers_recv: 26159,
          buffers_sent: 26159
        },
        {:srtcp_decryptor, #Reference<0.3468890940.1030750211.215664>} => %{
          avg_proc_time: 57847.870916334665,
          buffers_recv: 3765,
          buffers_sent: 3765
        },
        {:srtcp_encryptor, #Reference<0.3468890940.1030750211.215664>} => %{
          avg_proc_time: 62205.89328358209,
          buffers_recv: 1340,
          buffers_sent: 1340
        },
        {:srtcp_sender_encryptor, 2441442936} => %{
          avg_proc_time: 98232.77486910994,
          buffers_recv: 191,
          buffers_sent: 191
        },
        {:srtcp_sender_encryptor, 2832125492} => %{
          avg_proc_time: 84929.2670157068,
          buffers_recv: 191,
          buffers_sent: 191
        },
        {:srtp_encryptor, 2441442936} => %{
          avg_proc_time: 49848.68564710222,
          buffers_recv: 21689,
          buffers_sent: 21689
        },
        {:srtp_encryptor, 2832125492} => %{
          avg_proc_time: 42435.15377388036,
          buffers_recv: 9579,
          buffers_sent: 9579
        },
        {:stream_receive_bin, 907595673} => %{
          decryptor: %{
            avg_proc_time: 70191.66066741657,
            buffers_recv: 2667,
            buffers_sent: 2667
          },
          packet_tracker: %{
            avg_proc_time: 36696.42557180353,
            buffers_recv: 2667,
            buffers_sent: 2667
          },
          rtcp_receiver: %{
            avg_proc_time: 13423.809523809523,
            buffers_recv: 2667,
            buffers_sent: 2666
          }
        },
        {:stream_receive_bin, 1394776385} => %{
          decryptor: %{
            avg_proc_time: 72040.12613322822,
            buffers_recv: 10148,
            buffers_sent: 10148
          },
          packet_tracker: %{
            avg_proc_time: 34122.18831296807,
            buffers_recv: 10148,
            buffers_sent: 10148
          },
          rtcp_receiver: %{
            avg_proc_time: 7940.682499014584,
            buffers_recv: 10148,
            buffers_sent: 10148
          }
        },
        {:stream_receive_bin, 3171476947} => %{
          decryptor: %{
            avg_proc_time: 60820.71802902182,
            buffers_recv: 9579,
            buffers_sent: 9579
          },
          packet_tracker: %{
            avg_proc_time: 35749.983088005014,
            buffers_recv: 9579,
            buffers_sent: 9579
          },
          rtcp_receiver: %{
            avg_proc_time: 8085.324355360684,
            buffers_recv: 9579,
            buffers_sent: 9579
          }
        },
        {:stream_send_bin, 2441442936} => %{
          packet_tracker: %{
            avg_proc_time: 29452.007884180923,
            buffers_recv: 21689,
            buffers_sent: 21880
          }
        },
        {:stream_send_bin, 2832125492} => %{
          packet_tracker: %{
            avg_proc_time: 36107.4457667815,
            buffers_recv: 9579,
            buffers_sent: 9770
          }
        }
      }
    },
    {:track_receiver,
     "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:0d9986a4-cbfd-4e30-8ccb-0f8075965679"} => %{
      avg_proc_time: 19306.505480739117,
      buffers_recv: 9579,
      buffers_sent: 9579
    },
    {:track_receiver,
     "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:e8fa49d1-fd03-41c3-a6eb-1c82b1257c13"} => %{
      avg_proc_time: 34772.83986152324,
      buffers_recv: 10110,
      buffers_sent: 21689
    },
    {:track_sender,
     "f33c2f00-4730-4805-bd86-04a5ada402ec:5671201d-cef4-4f0f-94b8-ef38dea6073b"} => %{
      avg_proc_time: 56429.608037456106,
      buffers_recv: 12815,
      buffers_sent: 12815
    },
    {:track_sender,
     "f33c2f00-4730-4805-bd86-04a5ada402ec:779faa6c-9c26-438a-8852-df6b7959bb5e"} => %{
      avg_proc_time: 46329.704770852906,
      buffers_recv: 9579,
      buffers_sent: 9579
    }
  },
  {:tee,
   "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:0d9986a4-cbfd-4e30-8ccb-0f8075965679"} => %{
    avg_proc_time: 15591.043363460953,
    buffers_recv: 9847,
    buffers_sent: 9579
  },
  {:tee,
   "779e3aa3-6219-4ea0-b10c-27284fa1ee3e:e8fa49d1-fd03-41c3-a6eb-1c82b1257c13"} => %{
    avg_proc_time: 13392.309877389383,
    buffers_recv: 13131,
    buffers_sent: 10110
  },
  {:tee,
   "f33c2f00-4730-4805-bd86-04a5ada402ec:5671201d-cef4-4f0f-94b8-ef38dea6073b"} => %{
    avg_proc_time: 14634.171439719079,
    buffers_recv: 12815,
    buffers_sent: 10170
  },
  {:tee,
   "f33c2f00-4730-4805-bd86-04a5ada402ec:779faa6c-9c26-438a-8852-df6b7959bb5e"} => %{
    avg_proc_time: 15429.03538991544,
    buffers_recv: 9579,
    buffers_sent: 9561
  }
}
```