### PR TITLE
Bugfix pipeline call v0.11

### DIFF
--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -132,13 +132,14 @@ defmodule Membrane.Core.Pipeline do
   def handle_call(message, from, state) do
     context = &CallbackContext.Call.from_state(&1, from: from)
 
-    CallbackHandler.exec_and_handle_callback(
-      :handle_call,
-      Membrane.Core.Pipeline.ActionHandler,
-      %{context: context},
-      [message],
-      state
-    )
+    state =
+      CallbackHandler.exec_and_handle_callback(
+        :handle_call,
+        Membrane.Core.Pipeline.ActionHandler,
+        %{context: context},
+        [message],
+        state
+      )
 
     {:noreply, state}
   end

--- a/test/membrane/integration/synchronous_pipeline_call_test.exs
+++ b/test/membrane/integration/synchronous_pipeline_call_test.exs
@@ -1,6 +1,8 @@
 defmodule PipelineSynchronousCallTest do
   use ExUnit.Case, async: false
 
+  import Membrane.Testing.Assertions
+
   alias Membrane.Pipeline
 
   @msg "Some message"
@@ -45,5 +47,33 @@ defmodule PipelineSynchronousCallTest do
 
     reply = Pipeline.call(pid, {:instant_reply, @msg})
     assert reply == @msg
+  end
+
+  defmodule PipelineSpawningChildrenOnCall do
+    use Membrane.Pipeline
+
+    @impl true
+    def handle_init(_ctx, _options) do
+      {[], %{}}
+    end
+
+    @impl true
+    def handle_call(:spawn_children, _ctx, state) do
+      spec =
+        child(:source, %Membrane.Testing.Source{output: [1, 2, 3]})
+        |> child(:sink, Membrane.Testing.Sink)
+
+      {[spec: spec, playback: :playing, reply: nil], state}
+    end
+  end
+
+  test "Pipeline should be able to perform actions before replying on handle_call" do
+    {:ok, _supervisor, pipeline_pid} =
+      Membrane.Testing.Pipeline.start(module: PipelineSpawningChildrenOnCall)
+
+    Membrane.Pipeline.call(pipeline_pid, :spawn_children)
+    assert_pipeline_play(pipeline_pid)
+    assert_end_of_stream(pipeline_pid, :sink)
+    Pipeline.terminate(pipeline_pid, blocking?: true)
   end
 end


### PR DESCRIPTION
This PR fixes a bug with a pipeline's state not being updated with the result of handle_callback invocation