### PR TITLE
Fix the bug with pipeline persisting in Zombie mode after self-terminating with `terminate: :normal` action

### DIFF
--- a/lib/membrane/core/parent/lifecycle_controller.ex
+++ b/lib/membrane/core/parent/lifecycle_controller.ex
@@ -81,6 +81,8 @@ defmodule Membrane.Core.Parent.LifecycleController do
 
   @spec handle_terminate(Parent.state()) :: {:continue | :stop, Parent.state()}
   def handle_terminate(state) do
+    state = %{state | terminating?: true}
+
     if Enum.empty?(state.children) do
       {:stop, state}
     else

--- a/lib/membrane/core/pipeline/action_handler.ex
+++ b/lib/membrane/core/pipeline/action_handler.ex
@@ -95,8 +95,6 @@ defmodule Membrane.Core.Pipeline.ActionHandler do
 
   @impl CallbackHandler
   def handle_action({:terminate, :normal}, _cb, _params, state) do
-    state = %{state | terminating?: true}
-
     case LifecycleController.handle_terminate(state) do
       {:continue, state} -> state
       {:stop, _state} -> exit(:normal)

--- a/lib/membrane/core/pipeline/action_handler.ex
+++ b/lib/membrane/core/pipeline/action_handler.ex
@@ -95,6 +95,8 @@ defmodule Membrane.Core.Pipeline.ActionHandler do
 
   @impl CallbackHandler
   def handle_action({:terminate, :normal}, _cb, _params, state) do
+    state = %{state | terminating?: true}
+
     case LifecycleController.handle_terminate(state) do
       {:continue, state} -> state
       {:stop, _state} -> exit(:normal)

--- a/test/membrane/core/pipeline_test.exs
+++ b/test/membrane/core/pipeline_test.exs
@@ -129,6 +129,16 @@ defmodule Membrane.Core.PipelineTest do
     end)
   end
 
+  test "Pipeline should be able to terminate itself with terminate: :normal action when it has already spawned children" do
+    {:ok, _supervisor, pid} = Testing.Pipeline.start(module: TestPipeline)
+    Process.monitor(pid)
+    spec = child(:source, %Testing.Source{output: [1, 2, 3]}) |> child(:sink, Testing.Sink)
+    Testing.Pipeline.execute_actions(pid, spec: spec)
+    assert_end_of_stream(pid, :sink)
+    Testing.Pipeline.execute_actions(pid, terminate: :normal)
+    assert_receive {:DOWN, _ref, :process, ^pid, :normal}
+  end
+
   test "Pipeline should be able to spawn its children in a nested specification" do
     pid = Testing.Pipeline.start_link_supervised!(module: TestPipeline)
     opts1 = []

--- a/test/membrane/element_test.exs
+++ b/test/membrane/element_test.exs
@@ -75,16 +75,16 @@ defmodule Membrane.ElementTest do
     [pipeline: pipeline]
   end
 
-  test "play", %{pipeline: pipeline} do
+  test "play", %{} do
     TestFilter.assert_callback_called(:handle_playing)
   end
 
   describe "Start of stream" do
-    test "causes handle_start_of_stream/3 to be called", %{pipeline: pipeline} do
+    test "causes handle_start_of_stream/3 to be called", %{} do
       TestFilter.assert_callback_called(:handle_start_of_stream)
     end
 
-    test "does not trigger calling callback handle_event/3", %{pipeline: pipeline} do
+    test "does not trigger calling callback handle_event/3", %{} do
       TestFilter.refute_callback_called(:handle_event)
     end
 
@@ -94,11 +94,11 @@ defmodule Membrane.ElementTest do
   end
 
   describe "End of stream" do
-    test "causes handle_end_of_stream/3 to be called", %{pipeline: pipeline} do
+    test "causes handle_end_of_stream/3 to be called", %{} do
       TestFilter.assert_callback_called(:handle_end_of_stream)
     end
 
-    test "does not trigger calling callback handle_event/3", %{pipeline: pipeline} do
+    test "does not trigger calling callback handle_event/3", %{} do
       TestFilter.refute_callback_called(:handle_event)
     end
 

--- a/test/membrane/element_test.exs
+++ b/test/membrane/element_test.exs
@@ -80,7 +80,7 @@ defmodule Membrane.ElementTest do
   end
 
   describe "Start of stream" do
-    test "causes handle_start_of_stream/3 to be called", %{} do
+    test "causes handle_start_of_stream/3 to be called" do
       TestFilter.assert_callback_called(:handle_start_of_stream)
     end
 

--- a/test/membrane/integration/elements_compatibility_test.exs
+++ b/test/membrane/integration/elements_compatibility_test.exs
@@ -2,7 +2,6 @@ defmodule Membrane.Integration.ElementsCompatibilityTest do
   use ExUnit.Case, async: true
 
   import Membrane.ChildrenSpec
-  import Membrane.Testing.Assertions
   alias Membrane.Testing.Pipeline
 
   defmodule StreamFormat do


### PR DESCRIPTION
Some additional small changes (removing unused variables and aliases from tests) have also been performed since my credo has been failing.