### PR TITLE
Stop calling handle_demand after end of stream

### DIFF
--- a/test/membrane/integration/demands_test.exs
+++ b/test/membrane/integration/demands_test.exs
@@ -6,6 +6,7 @@ defmodule Membrane.Integration.DemandsTest do
   import Membrane.ChildrenSpec
   import Membrane.Testing.Assertions
 
+  alias Membrane.Testing
   alias Membrane.Buffer
   alias Membrane.Support.DemandsTest.Filter
   alias Membrane.Testing.{Pipeline, Sink, Source}
@@ -74,5 +75,64 @@ defmodule Membrane.Integration.DemandsTest do
 
     pid = Pipeline.start_link_supervised!(spec: spec)
     test_pipeline(pid)
+  end
+
+  test "handle_demand is not called for pad with end of stream" do
+    defmodule Source do
+      use Membrane.Source
+
+      defmodule StreamFormat do
+        defstruct []
+      end
+
+      def_output_pad :output, flow_control: :manual, accepted_format: _any
+
+      @impl true
+      def handle_init(_ctx, _opts), do: {[], %{eos_sent?: false}}
+
+      @impl true
+      def handle_demand(_pad, _size, _unit, _ctx, %{eos_sent?: true}) do
+        raise "handle_demand cannot be called after sending end of stream"
+      end
+
+      @impl true
+      def handle_demand(:output, n, :buffers, _ctx, %{eos_sent?: false} = state) do
+        IO.inspect(n, label: "N TO")
+
+        buffers =
+          1..(n - 1)//1
+          |> Enum.map(fn _i -> %Membrane.Buffer{payload: <<>>} end)
+
+        Process.send_after(self(), :second_left, 1000)
+
+        {[stream_format: {:output, %StreamFormat{}}, buffer: {:output, buffers}], state}
+      end
+
+      @impl true
+      def handle_info(:second_left, _ctx, %{eos_sent?: false} = state) do
+        buffer = %Membrane.Buffer{payload: <<>>}
+        state = %{state | eos_sent?: true}
+
+        {[buffer: {:output, buffer}, end_of_stream: :output], state}
+      end
+    end
+
+    defmodule Sink do
+      use Membrane.Sink
+
+      def_input_pad :input, flow_control: :manual, demand_unit: :buffers, accepted_format: _any
+
+      @impl true
+      def handle_playing(_ctx, state), do: {[demand: {:input, 1}], state}
+
+      @impl true
+      def handle_buffer(:input, _buffer, _ctx, state), do: {[demand: {:input, 1}], state}
+    end
+
+    pipeline = Testing.Pipeline.start_link_supervised!(spec: child(Source) |> child(:sink, Sink))
+
+    assert_end_of_stream(pipeline, :sink)
+
+    Testing.Pipeline.terminate(pipeline)
   end
 end


### PR DESCRIPTION
Related Jira ticket: https://membraneframework.atlassian.net/browse/MC-204