### PR TITLE
Improve `in_progress_memory` metric in performance benchmark

### DIFF
--- a/benchmark/metric/in_progress_memory.ex
+++ b/benchmark/metric/in_progress_memory.ex
@@ -33,7 +33,7 @@ defmodule Benchmark.Metric.InProgressMemory do
 
   @impl true
   def start_meassurement(_opts \\ nil) do
-    Process.list() |> Enum.each(:erlang.garbage_collect(&1))
+    Process.list() |> Enum.each(&:erlang.garbage_collect(&1))
     initial_memory = :erlang.memory(:total)
 
     task =

--- a/benchmark/metric/in_progress_memory.ex
+++ b/benchmark/metric/in_progress_memory.ex
@@ -33,6 +33,7 @@ defmodule Benchmark.Metric.InProgressMemory do
 
   @impl true
   def start_meassurement(_opts \\ nil) do
+    Process.list() |> Enum.each(:erlang.garbage_collect(&1))
     initial_memory = :erlang.memory(:total)
 
     task =

--- a/benchmark/metric/in_progress_memory.ex
+++ b/benchmark/metric/in_progress_memory.ex
@@ -37,17 +37,17 @@ defmodule Benchmark.Metric.InProgressMemory do
 
     task =
       Task.async(fn ->
-        do_loop([])
+        do_loop()
       end)
 
     task
   end
 
-  defp do_loop(acc) do
-    acc = acc ++ [:erlang.memory(:total)]
+  defp do_loop(acc \\ []) do
+    acc = [:erlang.memory(:total) | acc]
 
     receive do
-      :stop -> acc
+      :stop -> Enum.reverse(acc)
     after
       @sampling_period -> do_loop(acc)
     end

--- a/benchmark/metric/in_progress_memory.ex
+++ b/benchmark/metric/in_progress_memory.ex
@@ -34,23 +34,22 @@ defmodule Benchmark.Metric.InProgressMemory do
   @impl true
   def start_meassurement(_opts \\ nil) do
     Process.list() |> Enum.each(&:erlang.garbage_collect(&1))
-    initial_memory = :erlang.memory(:total)
 
     task =
       Task.async(fn ->
-        do_loop([], initial_memory)
+        do_loop([])
       end)
 
     task
   end
 
-  defp do_loop(acc, initial_memory) do
-    acc = acc ++ [:erlang.memory(:total) - initial_memory]
+  defp do_loop(acc) do
+    acc = acc ++ [:erlang.memory(:total)]
 
     receive do
       :stop -> acc
     after
-      @sampling_period -> do_loop(acc, initial_memory)
+      @sampling_period -> do_loop(acc)
     end
   end
 


### PR DESCRIPTION
This PR:
* Adds synchronous GC launch before the initial memory measurement in benchmark
* Removes calculation of the `initial_memory` in `in_progress_memory` metric