### PR TITLE
Make error in `LinkUtils.handle_child_pad_removed` more descriptive

### DIFF
--- a/lib/membrane/core/parent/child_life_controller/link_utils.ex
+++ b/lib/membrane/core/parent/child_life_controller/link_utils.ex
@@ -38,21 +38,32 @@ defmodule Membrane.Core.Parent.ChildLifeController.LinkUtils do
 
   @spec handle_child_pad_removed(Child.name(), Pad.ref(), Parent.state()) :: Parent.state()
   def handle_child_pad_removed(child, pad, state) do
-    {:ok, link} = get_link(state.links, child, pad)
+    with {:ok, link} <- get_link(state.links, child, pad) do
+      state =
+        opposite_endpoint(link, child)
+        |> case do
+          %Endpoint{child: {Membrane.Bin, :itself}} = bin_endpoint ->
+            PadController.remove_pad(bin_endpoint.pad_ref, state)
 
-    state =
-      opposite_endpoint(link, child)
-      |> case do
-        %Endpoint{child: {Membrane.Bin, :itself}} = bin_endpoint ->
-          PadController.remove_pad(bin_endpoint.pad_ref, state)
+          %Endpoint{} = endpoint ->
+            Message.send(endpoint.pid, :handle_unlink, endpoint.pad_ref)
+            state
+        end
 
-        %Endpoint{} = endpoint ->
-          Message.send(endpoint.pid, :handle_unlink, endpoint.pad_ref)
-          state
-      end
+      ChildLifeController.remove_link_from_specs(link.id, state)
+      |> Map.update!(:links, &Map.delete(&1, link.id))
+    else
+      {:error, :not_found} ->
+        with %{^child => _child_entry} <- state.children do
+          raise ParentError, """
+          Attempted to unlink pad #{inspect(pad)} of child #{inspect(child)}, but this child does not have this pad linked
+          """
+        end
 
-    ChildLifeController.remove_link_from_specs(link.id, state)
-    |> Map.update!(:links, &Map.delete(&1, link.id))
+        raise ParentError, """
+        Attempted to unlink pad #{inspect(pad)} of child #{inspect(child)}, but such a child does not exist
+        """
+    end
   end
 
   @spec remove_link(Child.name(), Pad.ref(), Parent.state()) :: Parent.state()


### PR DESCRIPTION
Related issue: [RTC-315](https://membraneframework.atlassian.net/browse/RTC-315)

Right now, this fails with a match error. I blindly copied over the implementation from `remove_link`, you should change the messages as needed :smile:

[RTC-315]: https://membraneframework.atlassian.net/browse/RTC-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ