### PR TITLE
Spawn Membrane.Clock via subprocess supervisor in components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  * Implement `Membrane.Debug.Filter` and `Membrane.Debug.Sink`. [#552](https://github.com/membraneframework/membrane_core/pull/552)
  * Add `:pause_auto_demand` and `:resume_auto_demand` actions. [#586](https://github.com/membraneframework/membrane_core/pull/586)
  * Send `:end_of_stream`, even if it is not preceded by `:start_of_stream`. [#557](https://github.com/membraneframework/membrane_core/pull/577)
+ * Fix process leak in starting clocks. [#594](https://github.com/membraneframework/membrane_core/pull/594)
  
 ## 0.11.0
  * Separate element_name and pad arguments in handle_element_{start, end}_of_stream signature [#219](https://github.com/membraneframework/membrane_core/issues/219)

--- a/lib/membrane/core/bin.ex
+++ b/lib/membrane/core/bin.ex
@@ -95,7 +95,12 @@ defmodule Membrane.Core.Bin do
     Membrane.Core.Stalker.register_component(options.stalker, observability_config)
     SubprocessSupervisor.set_parent_component(options.subprocess_supervisor, observability_config)
 
-    clock_proxy = Membrane.Clock.start_link(proxy: true) ~> ({:ok, pid} -> pid)
+    {:ok, clock_proxy} =
+      SubprocessSupervisor.start_utility(
+        options.subprocess_supervisor,
+        {Membrane.Clock, proxy: true}
+      )
+
     clock = if Bunch.Module.check_behaviour(module, :membrane_clock?), do: clock_proxy, else: nil
     Message.send(options.parent, :clock, [name, clock])
 

--- a/lib/membrane/core/element/lifecycle_controller.ex
+++ b/lib/membrane/core/element/lifecycle_controller.ex
@@ -7,7 +7,7 @@ defmodule Membrane.Core.Element.LifecycleController do
   use Bunch
 
   alias Membrane.{Clock, Element, Sync}
-  alias Membrane.Core.{CallbackHandler, Element, Message}
+  alias Membrane.Core.{CallbackHandler, Element, Message, SubprocessSupervisor}
 
   alias Membrane.Core.Element.{
     ActionHandler,
@@ -33,7 +33,9 @@ defmodule Membrane.Core.Element.LifecycleController do
 
     clock =
       if Bunch.Module.check_behaviour(module, :membrane_clock?) do
-        {:ok, clock} = Clock.start_link()
+        {:ok, clock} =
+          SubprocessSupervisor.start_utility(state.subprocess_supervisor, {Clock, []})
+
         clock
       else
         nil

--- a/lib/membrane/core/pipeline.ex
+++ b/lib/membrane/core/pipeline.ex
@@ -42,12 +42,16 @@ defmodule Membrane.Core.Pipeline do
       Telemetry.report_terminate(:pipeline)
     end)
 
-    {:ok, clock} = Clock.start_link(proxy: true)
+    {:ok, clock_proxy} =
+      SubprocessSupervisor.start_utility(
+        params.subprocess_supervisor,
+        {Clock, proxy: true}
+      )
 
     state = %State{
       module: params.module,
       synchronization: %{
-        clock_proxy: clock,
+        clock_proxy: clock_proxy,
         clock_provider: %{clock: nil, provider: nil, choice: :auto},
         timers: %{}
       },


### PR DESCRIPTION
Related Jira ticket: https://membraneframework.atlassian.net/browse/MC-229