### PR TITLE
Remove default implementation of start, start_link and terminate functions from Membrane.Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
  * Send `:end_of_stream`, even if it is not preceded by `:start_of_stream`. [#557](https://github.com/membraneframework/membrane_core/pull/577)
  * Fix process leak in starting clocks. [#594](https://github.com/membraneframework/membrane_core/pull/594)
  * Add child exit reason to the supervisor exit reason. [#595](https://github.com/membraneframework/membrane_core/pull/595)
+ * Remove default implementation of `start_/2`, `start_link/2` and `terminate/2` in modules using `Membrane.Pipeline`. [#598](https://github.com/membraneframework/membrane_core/pull/598) 
  
 ## 0.11.0
  * Separate element_name and pad arguments in handle_element_{start, end}_of_stream signature [#219](https://github.com/membraneframework/membrane_core/issues/219)

--- a/benchmark/run.exs
+++ b/benchmark/run.exs
@@ -247,7 +247,8 @@ defmodule Benchmark.Run do
     time_meassurement = Time.start_meassurement()
 
     {:ok, _supervisor_pid, pipeline_pid} =
-      Benchmark.Run.Pipeline.start(
+      Membrane.Pipeline.start(
+        Benchmark.Run.Pipeline,
         monitoring_process: self(),
         spec: spec
       )

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -430,50 +430,6 @@ defmodule Membrane.Pipeline do
     :erpc.call(node, __MODULE__, :list_pipelines, [])
   end
 
-  @doc false
-  defmacro __before_compile__(_env) do
-    quote do
-      unless Enum.any?(0..2, &Module.defines?(__MODULE__, {:start_link, &1})) do
-        @doc """
-        Starts the pipeline `#{inspect(__MODULE__)}` and links it to the current process.
-
-        A proxy for `#{inspect(unquote(__MODULE__))}.start_link/3`
-        """
-        @spec start_link(
-                unquote(__MODULE__).pipeline_options(),
-                unquote(__MODULE__).config()
-              ) :: unquote(__MODULE__).on_start()
-        def start_link(pipeline_options \\ nil, process_options \\ []) do
-          unquote(__MODULE__).start_link(__MODULE__, pipeline_options, process_options)
-        end
-      end
-
-      unless Enum.any?(0..2, &Module.defines?(__MODULE__, {:start, &1})) do
-        @doc """
-        Starts the pipeline `#{inspect(__MODULE__)}` without linking it
-        to the current process.
-
-        A proxy for `#{inspect(unquote(__MODULE__))}.start/3`
-        """
-        @spec start(
-                unquote(__MODULE__).pipeline_options(),
-                unquote(__MODULE__).config()
-              ) :: unquote(__MODULE__).on_start()
-        def start(pipeline_options \\ nil, process_options \\ []) do
-          unquote(__MODULE__).start(__MODULE__, pipeline_options, process_options)
-        end
-      end
-
-      unless Enum.any?(1..2, &Module.defines?(__MODULE__, {:terminate, &1})) do
-        @doc """
-        Changes pipeline's playback to `:stopped` and terminates its process.
-        """
-        @spec terminate(pid, Keyword.t()) :: :ok | {:ok, pid()} | {:error, :timeout}
-        defdelegate terminate(pipeline, opts \\ []), to: unquote(__MODULE__)
-      end
-    end
-  end
-
   @doc """
   Brings all the stuff necessary to implement a pipeline.
 
@@ -502,8 +458,6 @@ defmodule Membrane.Pipeline do
     quote do
       alias unquote(__MODULE__)
       @behaviour unquote(__MODULE__)
-
-      @before_compile Pipeline
 
       unquote(bring_spec)
       unquote(bring_pad)

--- a/lib/membrane/rc_pipeline.ex
+++ b/lib/membrane/rc_pipeline.ex
@@ -90,6 +90,9 @@ defmodule Membrane.RCPipeline do
     pipeline
   end
 
+  @spec terminate(pid, Keyword.t()) :: :ok | {:ok, pid()} | {:error, :timeout}
+  defdelegate terminate(pipeline, opts \\ []), to: Pipeline
+
   defmacrop pin_leaf_nodes(ast) do
     quote do
       Macro.postwalk(unquote(ast), fn node ->

--- a/lib/membrane/testing/pipeline.ex
+++ b/lib/membrane/testing/pipeline.ex
@@ -198,6 +198,9 @@ defmodule Membrane.Testing.Pipeline do
     apply(ExUnit.Callbacks, :start_supervised, [child_spec])
   end
 
+  @spec terminate(pid, Keyword.t()) :: :ok | {:ok, pid()} | {:error, :timeout}
+  defdelegate terminate(pipeline, opts \\ []), to: Pipeline
+
   @doc """
   Sends message to a child by Element name.
 

--- a/test/membrane/integration/bin_test.exs
+++ b/test/membrane/integration/bin_test.exs
@@ -236,7 +236,7 @@ defmodule Membrane.Core.BinTest do
     end
 
     test "Bin is clock_provider" do
-      {:ok, _supervisor, pid} = ClockPipeline.start_link()
+      {:ok, _supervisor, pid} = Membrane.Pipeline.start_link(ClockPipeline)
 
       %Membrane.Core.Pipeline.State{synchronization: %{clock_provider: pipeline_clock_provider}} =
         state = :sys.get_state(pid)
@@ -253,7 +253,7 @@ defmodule Membrane.Core.BinTest do
       refute is_nil(clock2)
 
       assert proxy_for?(clock1, clock2)
-      ClockPipeline.terminate(pid)
+      Membrane.Pipeline.terminate(pid)
     end
 
     test "handle_parent_notification/3 works for Bin" do

--- a/test/membrane/integration/child_pad_removed_test.exs
+++ b/test/membrane/integration/child_pad_removed_test.exs
@@ -153,7 +153,7 @@ defmodule Membrane.Integration.ChildPadRemovedTest do
         assert_child_exists(pipeline, :bin)
         assert_child_exists(pipeline, :sink)
 
-        Pipeline.terminate(pipeline)
+        Membrane.Pipeline.terminate(pipeline)
       end
     end
 
@@ -196,7 +196,7 @@ defmodule Membrane.Integration.ChildPadRemovedTest do
         assert_receive {:DOWN, ^monitor_ref, :process, ^sink_pid, _reason}
         assert_child_exists(pipeline, :bin)
 
-        Pipeline.terminate(pipeline)
+        Membrane.Pipeline.terminate(pipeline)
       end
     end
   end


### PR DESCRIPTION
Related Jira ticket: https://membraneframework.atlassian.net/browse/MC-235
