### PR TITLE
Log messages in the default handle_info implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1
  * Specify the order in which state fields will be printed in the error logs. [#614](https://github.com/membraneframework/membrane_core/pull/614)
  * Fix clock selection [#626](https://github.com/membraneframework/membrane_core/pull/626)
+ * Log messages in the default handle_info implementation [#680](https://github.com/membraneframework/membrane_core/pull/680)
 
 ## 1.0.0
  * Introduce `:remove_link` action in pipelines and bins.

--- a/lib/membrane/bin.ex
+++ b/lib/membrane/bin.ex
@@ -135,7 +135,7 @@ defmodule Membrane.Bin do
   as an internal membrane message.
 
   Can be used for receiving data from non-membrane processes.
-  By default, it ignores the received message.
+  By default, it logs and ignores the received message.
   """
   @callback handle_info(
               message :: any,
@@ -317,6 +317,7 @@ defmodule Membrane.Bin do
         only: [def_input_pad: 2, def_output_pad: 2, def_options: 1, def_clock: 0, def_clock: 1]
 
       require Membrane.Core.Child.PadsSpecs
+      require Membrane.Logger
 
       Membrane.Core.Child.PadsSpecs.ensure_default_membrane_pads()
 
@@ -344,7 +345,14 @@ defmodule Membrane.Bin do
       def handle_playing(_ctx, state), do: {[], state}
 
       @impl true
-      def handle_info(message, _ctx, state), do: {[], state}
+      def handle_info(message, _ctx, state) do
+        Membrane.Logger.warning("""
+        Received message but no handle_info callback has been specified. Ignoring.
+        Message: #{inspect(message)}\
+        """)
+
+        {[], state}
+      end
 
       @impl true
       def handle_spec_started(new_children, _ctx, state), do: {[], state}

--- a/lib/membrane/element/base.ex
+++ b/lib/membrane/element/base.ex
@@ -78,7 +78,7 @@ defmodule Membrane.Element.Base do
   as an internal membrane message.
 
   Useful for receiving ticks from timer, data sent from NIFs or other stuff.
-  By default, it ignores the received message.
+  By default, it logs and ignores the received message.
   """
   @callback handle_info(
               message :: any(),
@@ -251,6 +251,7 @@ defmodule Membrane.Element.Base do
       import unquote(__MODULE__), only: [def_clock: 0, def_clock: 1, def_options: 1]
 
       require Membrane.Core.Child.PadsSpecs
+      require Membrane.Logger
 
       Membrane.Core.Child.PadsSpecs.ensure_default_membrane_pads()
 
@@ -274,7 +275,14 @@ defmodule Membrane.Element.Base do
       def handle_playing(_context, state), do: {[], state}
 
       @impl true
-      def handle_info(_message, _context, state), do: {[], state}
+      def handle_info(message, _context, state) do
+        Membrane.Logger.warning("""
+        Received message but no handle_info callback has been specified. Ignoring.
+        Message: #{inspect(message)}\
+        """)
+
+        {[], state}
+      end
 
       @impl true
       def handle_pad_added(_pad, _context, state), do: {[], state}

--- a/lib/membrane/pipeline.ex
+++ b/lib/membrane/pipeline.ex
@@ -170,7 +170,7 @@ defmodule Membrane.Pipeline do
   as an internal membrane message.
 
   Useful for receiving data sent from NIFs or other stuff.
-  By default, it ignores the received message.
+  By default, it logs and ignores the received message.
   """
   @callback handle_info(
               message :: any,
@@ -457,6 +457,7 @@ defmodule Membrane.Pipeline do
     # credo:disable-for-next-line Credo.Check.Refactor.LongQuoteBlocks
     quote do
       alias unquote(__MODULE__)
+      require Membrane.Logger
       @behaviour unquote(__MODULE__)
 
       unquote(bring_spec)
@@ -492,7 +493,14 @@ defmodule Membrane.Pipeline do
       def handle_playing(_ctx, state), do: {[], state}
 
       @impl true
-      def handle_info(message, _ctx, state), do: {[], state}
+      def handle_info(message, _ctx, state) do
+        Membrane.Logger.warning("""
+        Received message but no handle_info callback has been specified. Ignoring.
+        Message: #{inspect(message)}\
+        """)
+
+        {[], state}
+      end
 
       @impl true
       def handle_spec_started(new_children, _ctx, state), do: {[], state}


### PR DESCRIPTION
The default implementation of GenServer's handle_info logs and drops incoming messages. See [here](https://hexdocs.pm/elixir/GenServer.html#c:handle_info/2) and [here](https://github.com/elixir-lang/elixir/blob/v1.15.7/lib/elixir/lib/gen_server.ex#L838)

Because our handle_info is called the same way as GenServer's handle_info, I think we should mime GenServer's handle_info behaviour and log incoming messages too?

For the context, see this [issue](https://github.com/elixir-grpc/grpc/issues/337).

 