### PR TITLE
Fix timer running late

### DIFF
--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -256,6 +256,16 @@ defmodule Membrane.Core.Element do
   end
 
   defp do_handle_info(Message.new(:timer_tick, timer_id), state) do
+    # Guarding the `TimerController.handle_tick/2` invocation is
+    # required since there might be a case in which `handle_tick`
+    # callback's implementation returns demand action.
+    # In this scenario, without this guard, there would a possibility that
+    # the `handle_buffer` would be called immediately, returning
+    # some action that would affect the timer and the original state
+    # of the timer, set with actions returned from `handle_tick`,
+    # would be overwritten with that action.
+    #
+    # For more information see: https://github.com/membraneframework/membrane_core/issues/670
     state = %{state | supplying_demand?: true}
     state = TimerController.handle_tick(timer_id, state)
     state = %{state | supplying_demand?: false}

--- a/lib/membrane/core/element.ex
+++ b/lib/membrane/core/element.ex
@@ -256,7 +256,10 @@ defmodule Membrane.Core.Element do
   end
 
   defp do_handle_info(Message.new(:timer_tick, timer_id), state) do
+    state = %{state | supplying_demand?: true}
     state = TimerController.handle_tick(timer_id, state)
+    state = %{state | supplying_demand?: false}
+    state = Membrane.Core.Element.DemandHandler.handle_delayed_demands(state)
     {:noreply, state}
   end
 

--- a/lib/membrane/core/timer_controller.ex
+++ b/lib/membrane/core/timer_controller.ex
@@ -58,8 +58,6 @@ defmodule Membrane.Core.TimerController do
 
   @spec handle_tick(Timer.id(), Component.state()) :: Component.state()
   def handle_tick(timer_id, state) when is_timer_present(timer_id, state) do
-    state = %{state | supplying_demand?: true}
-
     state =
       CallbackHandler.exec_and_handle_callback(
         :handle_tick,
@@ -70,15 +68,11 @@ defmodule Membrane.Core.TimerController do
       )
 
     # in case the timer was removed in handle_tick
-    state =
-      if is_timer_present(timer_id, state) do
-        update_in(state, [:synchronization, :timers, timer_id], &Timer.tick/1)
-      else
-        state
-      end
-
-    state = %{state | supplying_demand?: false}
-    Membrane.Core.Element.DemandHandler.handle_delayed_demands(state)
+    if is_timer_present(timer_id, state) do
+      update_in(state, [:synchronization, :timers, timer_id], &Timer.tick/1)
+    else
+      state
+    end
   end
 
   def handle_tick(_timer_id, state) do


### PR DESCRIPTION
This PR: 
* guards the timer tick in `TimerController.handle_tick` with supplying_demand? flag