### PR TITLE
Fix python script used by GitHub actions

### DIFF
--- a/scripts/python/get_ticket_id.py
+++ b/scripts/python/get_ticket_id.py
@@ -2,5 +2,5 @@ import sys, json;
 
 project_items = json.load(sys.stdin)["items"]
 pr_url = sys.argv[1]
-[id] = [item["id"] for item in project_items if item["content"]["url"] == pr_url]
+[id] = [item["id"] for item in project_items if ("url" in item["content"] and item["content"]["url"] == pr_url)]
 print(id)


### PR DESCRIPTION
get_ticket_id.py was crashing if "url" key was missing in json. 

solves: https://github.com/membraneframework/membrane_core/issues/716#issue-2098760654