### PR TITLE
Fix 'table identifier does not refer to an existing ETS table' error when inserting metrics into the observability ETS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.1
+* Fix 'table identifier does not refer to an existing ETS table' error when inserting metrics into the observability ETS [#835](https://github.com/membraneframework/membrane_core/pull/835)
+
 ## 1.1.0
  * Add new callbacks `handle_child_setup_completed/3` and `handle_child_playing/3` in Bins and Pipelines. [#801](https://github.com/membraneframework/membrane_core/pull/801)
  * Deprecate `handle_spec_started/3` callback in Bins and Pipelines. [#708](https://github.com/membraneframework/membrane_core/pull/708)

--- a/lib/membrane/core/parent/child_life_controller/startup_utils.ex
+++ b/lib/membrane/core/parent/child_life_controller/startup_utils.ex
@@ -34,7 +34,7 @@ defmodule Membrane.Core.Parent.ChildLifeController.StartupUtils do
     sinks =
       children
       |> Enum.filter(
-        &(Membrane.Element.element?(&1.module) and &1.module.membrane_element_type == :sink)
+        &(Membrane.Element.element?(&1.module) and &1.module.membrane_element_type() == :sink)
       )
       |> Enum.map(& &1.name)
 

--- a/lib/membrane/core/utils.ex
+++ b/lib/membrane/core/utils.ex
@@ -16,16 +16,15 @@ defmodule Membrane.Core.Utils do
       try do
         unquote(code)
       rescue
-        e ->
+        error ->
           require Membrane.Logger
 
           Membrane.Logger.error("""
           Error occured in #{unquote(error_source)}:
-          #{inspect(e, pretty: true, limit: :infinity)}
-          #{Exception.format_stacktrace(__STACKTRACE__)}
+          #{Exception.format(:error, error, __STACKTRACE__)}
           """)
 
-          reraise e, __STACKTRACE__
+          reraise error, __STACKTRACE__
       end
     end
   end


### PR DESCRIPTION
closes #814 